### PR TITLE
Add simple sites map

### DIFF
--- a/api/controllers/sites.js
+++ b/api/controllers/sites.js
@@ -2,7 +2,7 @@ const rp = require('request-promise');
 const CARTO_SQL = require('../constants').CARTO_SQL;
 
 function getSites(req, res) {
-  rp(`${CARTO_SQL}q=SELECT * FROM sites`)
+  rp(`${CARTO_SQL}q=SELECT * FROM sites LIMIT 50`)
     .then((data) => {
       const result = JSON.parse(data);
       if (result.rows && result.rows.length > 0) {

--- a/app/components/maps/SitesMap.js
+++ b/app/components/maps/SitesMap.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import L from 'leaflet'; // eslint-disable-line no-unresolved
+
+class Map extends React.Component {
+
+  componentDidMount() {
+    this.map = L.map('map-base', {
+      minZoom: 2,
+      zoom: 3,
+      center: [52, 7],
+      detectRetina: true
+    });
+
+    this.map.attributionControl.addAttribution('&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>');
+    this.map.zoomControl.setPosition('topright');
+    this.map.scrollWheelZoom.disable();
+    this.tileLayer = L.tileLayer('http://{s}.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png').addTo(this.map).setZIndex(0);
+
+    this.setMarkers();
+  }
+
+  componentWillUnmount() {
+    this.map.remove();
+  }
+
+  setMarkers() {
+    this.markers = [];
+    this.props.sites.forEach((site) => {
+      const marker = L.marker([site.lat, site.lon]).addTo(this.map);
+      marker.bindPopup(site.site_name);
+      marker.on('mouseover', function () {
+        this.openPopup();
+      });
+      marker.on('mouseout', function () {
+        this.closePopup();
+      });
+      this.markers.push(marker);
+    });
+  }
+
+  render() {
+    return (
+      <div className="l-maps-container">
+        <div id={'map-base'} className="c-map -full"></div>
+      </div>
+    );
+  }
+}
+
+Map.propTypes = {
+  sites: React.PropTypes.array
+};
+
+export default Map;

--- a/app/components/pages/SitesPage.js
+++ b/app/components/pages/SitesPage.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import SitesMap from 'components/maps/SitesMap';
 import LoadingSpinner from 'components/common/LoadingSpinner';
 
 class SitesPage extends React.Component {
@@ -8,14 +9,13 @@ class SitesPage extends React.Component {
     }
   }
 
-  render() {
+  getContent() {
     return (
-      <div className="row">
-        <div className="column">
-          <h2>{this.context.t('sites')}</h2>
-          {!this.props.sites.length
-            ? <LoadingSpinner transparent />
-            : <table>
+      <div>
+        <SitesMap sites={this.props.sites} />
+        <div className="row">
+          <div className="column">
+            <table>
               <thead>
                 <tr>
                   <th>Name</th>
@@ -31,6 +31,23 @@ class SitesPage extends React.Component {
                 ))}
               </tbody>
             </table>
+          </div>
+        </div>
+      </div>
+    );
+  }
+  render() {
+    return (
+      <div className="l-page">
+        <div className="row">
+          <div className="column">
+            <h2>{this.context.t('sites')}</h2>
+          </div>
+        </div>
+        <div className="l-page-content">
+          {!this.props.sites.length
+            ? <LoadingSpinner transparent />
+            : this.getContent()
           }
         </div>
       </div>

--- a/app/index.html
+++ b/app/index.html
@@ -25,6 +25,7 @@
     <meta name="theme-color" content="#ffffff">
 
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,600,700|Ubuntu:400,700" rel="stylesheet">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.1/dist/leaflet.css" />
 
   </head>
 
@@ -44,6 +45,7 @@
       </svg>
     </div>
     <div id="app"></div>
+    <script src="https://unpkg.com/leaflet@1.0.1/dist/leaflet.js"></script>
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Promise,fetch"></script>
   </body>
 </html>

--- a/app/styles/components/index.pcss
+++ b/app/styles/components/index.pcss
@@ -8,3 +8,6 @@
 @import "common/c-stay-update.pcss";
 @import "common/c-main-nav.pcss";
 @import "common/c-loading-spinner.pcss";
+
+/* Maps */
+@import "maps/c-map.pcss";

--- a/app/styles/components/maps/c-map.pcss
+++ b/app/styles/components/maps/c-map.pcss
@@ -1,0 +1,3 @@
+.c-map {
+  height: 500px;
+}

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -27,6 +27,10 @@ const webpackConfig = {
     publicPath: '/'
   },
 
+  externals: {
+    leaflet: 'L'
+  },
+
   plugins: [
     new HtmlWebpackPlugin({
       template: 'app/index.html',


### PR DESCRIPTION
Very simple map of sites marker.

![image](https://cloud.githubusercontent.com/assets/10500650/19981402/0edd6112-a202-11e6-9202-7c06cd52453f.png)

The most important thing in the PR is the way to add libraries from cdn instead add in the bundle.js
You can check it [here](https://github.com/Vizzuality/csn-tool/compare/develop...feature/sites-map?expand=1#diff-a58d55bdb5770c78ad512f8e91f8d051R30)