### PR TITLE
Feature/map url params

### DIFF
--- a/app/components/countries/CountriesMap.js
+++ b/app/components/countries/CountriesMap.js
@@ -101,21 +101,6 @@ class CountriesMap extends BasicMap {
     }
   }
 
-  addTopoJSONLayer() {
-    L.TopoJSON = L.GeoJSON.extend({
-      addData(jsonData) {
-        if (jsonData.type === 'Topology') {
-          Object.keys(jsonData.objects).forEach((key) => {
-            const geojson = topojson.feature(jsonData, jsonData.objects[key]);
-            L.GeoJSON.prototype.addData.call(this, geojson);
-          });
-        } else {
-          L.GeoJSON.prototype.addData.call(this, jsonData);
-        }
-      }
-    });
-  }
-
   addLayer() {
     const query = 'SELECT * FROM mask';
 

--- a/app/components/countries/CountriesMap.js
+++ b/app/components/countries/CountriesMap.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { BASEMAP_TILE, BASEMAP_ATTRIBUTION_MAPBOX, BASEMAP_ATTRIBUTION_CARTO,
-         MAP_INITIAL_ZOOM, MAP_MIN_ZOOM, MAP_CENTER } from 'constants/map';
+import { withRouter } from 'react-router';
+import { BASEMAP_ATTRIBUTION_CARTO, MAP_MIN_ZOOM, MAP_CENTER } from 'constants/map';
+import BasicMap from 'components/maps/BasicMap';
 import { createLayer } from 'helpers/map';
 import CountriesLegend from 'containers/countries/CountriesLegend';
 
-class CountriesMap extends React.Component {
-
+class CountriesMap extends BasicMap {
   constructor() {
     super();
     this.styles = {
@@ -23,6 +23,7 @@ class CountriesMap extends React.Component {
     // Map initialization
     this.initMap();
     this.initPopup();
+    this.handleMapScroll(this.props.country);
 
     // Adds suppport to topojson
     this.addTopoJSONLayer();
@@ -45,10 +46,12 @@ class CountriesMap extends React.Component {
 
     if (newProps.layers.sites) {
       if (newProps.data && newProps.data.length) {
-        this.clearMarkers();
-        this.drawMarkers(newProps.data);
-        this.fitBounds();
-        this.addLayer();
+        if (this.props.data.length !== newProps.data.length) {
+          this.clearMarkers();
+          this.drawMarkers(newProps.data);
+          this.fitBounds();
+          this.addLayer();
+        }
       } else {
         this.clearMarkers();
       }
@@ -64,7 +67,7 @@ class CountriesMap extends React.Component {
   }
 
   componentWillUnmount() {
-    this.map.remove();
+    this.remove();
   }
 
   setPopupPosition(latLng) {
@@ -88,21 +91,6 @@ class CountriesMap extends React.Component {
       closeButton: false,
       offset: L.point(0, -6)
     }).setContent('');
-  }
-
-  initMap() {
-    this.map = L.map('countries-map', {
-      minZoom: MAP_MIN_ZOOM,
-      zoom: MAP_INITIAL_ZOOM,
-      center: [52, 7],
-      detectRetina: true,
-      zoomAnimation: false
-    });
-
-    this.map.attributionControl.addAttribution(BASEMAP_ATTRIBUTION_MAPBOX);
-    this.map.zoomControl.setPosition('topright');
-    this.handleMapScroll(this.props.country);
-    this.tileLayer = L.tileLayer(BASEMAP_TILE).addTo(this.map).setZIndex(0);
   }
 
   handleMapScroll(country) {
@@ -263,7 +251,7 @@ class CountriesMap extends React.Component {
   render() {
     return (
       <div className="l-maps-container">
-        <div id={'countries-map'} className="c-map"></div>
+        <div id={this.props.id} className="c-map"></div>
         {this.props.country &&
           <div className="l-legend">
             <CountriesLegend />
@@ -276,6 +264,8 @@ class CountriesMap extends React.Component {
 
 
 CountriesMap.propTypes = {
+  id: React.PropTypes.string.isRequired,
+  router: React.PropTypes.object.isRequired,
   goToSite: React.PropTypes.func.isRequired,
   goToDetail: React.PropTypes.func.isRequired,
   getGeoms: React.PropTypes.func.isRequired,
@@ -284,4 +274,4 @@ CountriesMap.propTypes = {
   country: React.PropTypes.string
 };
 
-export default CountriesMap;
+export default withRouter(CountriesMap);

--- a/app/components/home/Banner.js
+++ b/app/components/home/Banner.js
@@ -4,7 +4,7 @@ import BasicMap from 'components/maps/BasicMap';
 function Banner(props, context) {
   return (
     <div className="c-banner">
-      <BasicMap />
+      <BasicMap id="home-map" urlSync={false} shareControl={false} />
       <div className="content">
         <svg>
           <use xlinkHref="#logo-big"></use>

--- a/app/components/maps/BasicMap.js
+++ b/app/components/maps/BasicMap.js
@@ -1,5 +1,9 @@
 import React from 'react';
-import { BASEMAP_TILE, BASEMAP_ATTRIBUTION_MAPBOX, MAP_MIN_ZOOM, MAP_CENTER, MAP_MAX_BOUNDS, MAP_INITIAL_ZOOM } from 'constants/map';
+import { BASEMAP_TILE, BASEMAP_ATTRIBUTION_MAPBOX, MAP_MIN_ZOOM,
+  MAP_CENTER, MAP_MAX_BOUNDS, MAP_INITIAL_ZOOM } from 'constants/map';
+import { render } from 'react-dom';
+import Share from 'components/maps/Share';
+import { replaceUrlParams } from 'helpers/router';
 
 class Map extends React.Component {
 
@@ -16,10 +20,98 @@ class Map extends React.Component {
     this.map.attributionControl.addAttribution(BASEMAP_ATTRIBUTION_MAPBOX);
     this.map.scrollWheelZoom.disable();
     this.tileLayer = L.tileLayer(BASEMAP_TILE).addTo(this.map).setZIndex(0);
+
+    if (this.props.urlSync) this.setUrlSyncListeners();
   }
 
   componentWillUnmount() {
+    this.remove();
+  }
+
+  getMapParams() {
+    const latLng = this.map.getCenter();
+    return {
+      zoom: this.map.getZoom(),
+      lat: latLng.lat,
+      lng: latLng.lng
+    };
+  }
+
+  setMapParams() {
+    const route = this.props.router.getCurrentLocation();
+    const url = replaceUrlParams(route.pathname + route.search, this.getMapParams());
+    this.props.router.push(url);
+  }
+
+  setUrlSyncListeners() {
+    this.map.on('dragend', this.setMapParams.bind(this));
+    this.map.on('zoomend', this.setMapParams.bind(this));
+  }
+
+  unsetUrlSyncListeners() {
+    this.map.off('dragend', this.setMapParams.bind(this));
+    this.map.off('zoomend', this.setMapParams.bind(this));
+  }
+
+  remove() {
     this.map.remove();
+    if (this.props.urlSync) this.unsetUrlSyncListeners();
+  }
+
+  initMap() {
+    const query = this.props.router.getCurrentLocation().query;
+    const center = query.lat && query.lng
+     ? [query.lat, query.lng]
+     : MAP_CENTER;
+    this.map = L.map(this.props.id, {
+      minZoom: MAP_MIN_ZOOM,
+      zoom: query.zoom || MAP_INITIAL_ZOOM,
+      center,
+      detectRetina: true,
+      zoomAnimation: false
+    });
+
+    if (this.props.markerCluster) {
+      this.markers = L.markerClusterGroup({
+        showCoverageOnHover: false,
+        removeOutsideVisibleBounds: true,
+        animate: false,
+        animateAddingMarkers: false,
+        chunkedLoading: true,
+        iconCreateFunction(cluster) {
+          return L.divIcon({
+            html: `<span>${cluster.getAllChildMarkers().length}</span>`,
+            className: 'marker-cluster',
+            iconSize: L.point(28, 28)
+          });
+        }
+      });
+    }
+
+    this.map.attributionControl.addAttribution(BASEMAP_ATTRIBUTION_MAPBOX);
+    this.map.zoomControl.setPosition('topright');
+    this.map.scrollWheelZoom.disable();
+    this.tileLayer = L.tileLayer(BASEMAP_TILE).addTo(this.map).setZIndex(0);
+
+    this.addShareControl();
+    if (this.props.urlSync) this.setUrlSyncListeners();
+  }
+
+  addShareControl() {
+    const LeafletShare = L.Control.extend({
+      options: {
+        position: 'topright'
+      },
+      onAdd() {
+        return L.DomUtil.create('div', 'leaflet-custom-control share-control');
+      }
+    });
+
+    this.map.addControl(new LeafletShare());
+    render(
+      <Share />,
+      document.getElementsByClassName('share-control')[0]
+    );
   }
 
   render() {
@@ -28,5 +120,16 @@ class Map extends React.Component {
     );
   }
 }
+
+Map.defaultProps = {
+  urlSync: true
+};
+
+Map.propTypes = {
+  id: React.PropTypes.string,
+  router: React.PropTypes.object,
+  markerCluster: React.PropTypes.bool,
+  urlSync: React.PropTypes.bool
+};
 
 export default Map;

--- a/app/components/maps/Share.js
+++ b/app/components/maps/Share.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+function Share() {
+  return (
+    <div className="c-share">
+      <a href={`mailto:?body=I think you could be interested on this website: ${window.location.href}`} className="share-btn -mail">
+        <svg width="20" height="16" viewBox="0 0 20 16"><title>rrss_email</title><path d="M10 10.159c-.333 0-.625-.12-1.25-.427L0 5.08v8.89c0 .698.563 1.27 1.25 1.27h17.5c.688 0 1.25-.572 1.25-1.27v-8.89l-8.75 4.653c-.625.307-.917.427-1.25.427zM18.75 0H1.25C.562 0 0 .571 0 1.27v.962l10 5.34 10-5.34V1.27C20 .57 19.437 0 18.75 0z" fillRule="evenodd" /></svg>
+      </a>
+      <a href="http://www.facebook.com/sharer/sharer.php%" target="_blank" className="share-btn -facebook">
+        <svg width="8" height="18" viewBox="0 0 8 18"><title>rrss_facebook</title><path d="M8 5.828H5.275V3.96c0-.701.445-.865.759-.865h1.922V.011L5.308 0C2.368 0 1.7 2.3 1.7 3.773v2.055H0v3.179h1.7V18h3.575V9.007h2.413L8 5.828z" fillRule="evenodd" /></svg>
+      </a>
+      <a href="http://www.twitter.com/share" target="_blank" className="share-btn -twitter">
+        <svg width="20" height="17" viewBox="0 0 20 17"><title>rrss_twitter</title><path d="M20 2.012a7.867 7.867 0 0 1-2.357.675A4.279 4.279 0 0 0 19.448.314a8.002 8.002 0 0 1-2.606 1.04A4.02 4.02 0 0 0 13.846 0C11.58 0 9.744 1.921 9.744 4.291c0 .336.035.665.105.978C6.44 5.09 3.416 3.382 1.392.785a4.43 4.43 0 0 0-.556 2.158c0 1.49.725 2.802 1.825 3.573a3.955 3.955 0 0 1-1.858-.537v.053c0 2.08 1.414 3.815 3.291 4.21a3.96 3.96 0 0 1-1.852.073c.521 1.704 2.037 2.945 3.832 2.98A8.005 8.005 0 0 1 0 15.073 11.256 11.256 0 0 0 6.29 17c7.547 0 11.674-6.54 11.674-12.21 0-.186-.005-.372-.012-.556A8.546 8.546 0 0 0 20 2.012z" fillRule="evenodd" /></svg>
+      </a>
+      <div className="share-btn -share">
+        <svg width="16" height="14" viewBox="0 0 16 14"><path fillRule="evenodd" d="M14.164 5.056l-2.612-2.657v.84c0 .385-.301.697-.685.697-2.136 0-3.78.572-4.902 1.7a5.285 5.285 0 0 0-1.092 1.63C6.494 6.3 8.541 6.126 9.8 6.126c.65 0 1.08.047 1.143.054.352.04.609.338.609.693v.84l2.612-2.657zm1.494.489l-4.285 4.359a.702.702 0 0 1-1.2-.49V7.53c-1.38-.04-4.695.1-5.89 2.226a.692.692 0 0 1-1.298-.34c0-.111.009-2.768 1.993-4.764C6.24 3.382 7.931 2.68 10.173 2.56V.697a.702.702 0 0 1 1.198-.49l4.285 4.36a.699.699 0 0 1 .002.978zm-3.072 6.433v.87c0 .385-.325.596-.71.596H.626c-.385 0-.626-.211-.626-.596V4.324C0 3.939.241 3.6.626 3.6h2.02a.691.691 0 1 1 0 1.382H1.379v7.08h9.828v-.084c0-.385.305-.697.69-.697.384 0 .69.312.69.697z" /></svg>
+      </div>
+    </div>
+  );
+}
+
+Share.propTypes = {};
+
+export default Share;

--- a/app/components/pages/CountriesPage.js
+++ b/app/components/pages/CountriesPage.js
@@ -52,7 +52,7 @@ class CountriesPage extends React.Component {
           </div>
         </div>
         <div className={`l-map ${this.props.country ? '-short -header' : '-header'}`}>
-          <CountriesMap />
+          <CountriesMap id="countries-map" />
         </div>
         <div className={`row l-content ${this.props.country ? '-short' : ''}`}>
           <div className="column">

--- a/app/components/pages/SitesDetailPage.js
+++ b/app/components/pages/SitesDetailPage.js
@@ -70,7 +70,7 @@ class SitesPage extends React.Component {
         </div>
         <div className="l-page">
           <div className="l-map -header -short">
-            <SitesMap slug={this.props.site} />
+            <SitesMap id="sites-detail-map" markerCluster slug={this.props.site} />
           </div>
           <div className="l-table">
             <div className="row l-content -short">

--- a/app/components/pages/SitesPage.js
+++ b/app/components/pages/SitesPage.js
@@ -48,7 +48,7 @@ class SitesPage extends React.Component {
         </div>
         <div className={`l-mask ${this.props.viewMode}`}>
           <div className={"l-map -header"}>
-            <SitesMap slug={this.props.selected} />
+            <SitesMap markerCluster slug={this.props.selected} id="sites-page-map" />
           </div>
           <div className="l-table">
             <div className="row">

--- a/app/components/pages/SpeciesDetailPage.js
+++ b/app/components/pages/SpeciesDetailPage.js
@@ -69,7 +69,7 @@ class SpeciesDetailPage extends React.Component {
           </div>
         </div>
         <div className="l-map -short -header">
-          <SpeciesDetailMap />
+          <SpeciesDetailMap id="species-detail-map" />
         </div>
         <div className="row l-content -short">
           <div className="column">

--- a/app/components/sites/SitesMap.js
+++ b/app/components/sites/SitesMap.js
@@ -1,48 +1,20 @@
 import React from 'react';
 import { withRouter } from 'react-router';
-import { BASEMAP_TILE, BASEMAP_ATTRIBUTION_MAPBOX, MAP_CENTER,
-         MAP_INITIAL_ZOOM, MAP_MIN_ZOOM } from 'constants/map';
-import { replaceUrlParams } from 'helpers/router';
+import BasicMap from 'components/maps/BasicMap';
 
-class SitesMap extends React.Component {
+class SitesMap extends BasicMap {
+  constructor(props) {
+    super(props);
+    this.markerList = [];
+  }
 
   componentDidMount() {
-    const query = this.props.router.getCurrentLocation().query;
-    const center = query.lat && query.lng
-     ? [query.lat, query.lng]
-     : MAP_CENTER;
-    this.map = L.map('map-base', {
-      minZoom: MAP_MIN_ZOOM,
-      zoom: query.zoom || MAP_INITIAL_ZOOM,
-      center,
-      detectRetina: true,
-      zoomAnimation: false
-    });
-    this.markers = L.markerClusterGroup({
-      showCoverageOnHover: false,
-      removeOutsideVisibleBounds: true,
-      animate: false,
-      animateAddingMarkers: false,
-      chunkedLoading: true,
-      iconCreateFunction(cluster) {
-        return L.divIcon({
-          html: `<span>${cluster.getAllChildMarkers().length}</span>`,
-          className: 'marker-cluster',
-          iconSize: L.point(28, 28)
-        });
-      }
-    });
-    this.markerList = [];
-
-    this.map.attributionControl.addAttribution(BASEMAP_ATTRIBUTION_MAPBOX);
-    this.map.zoomControl.setPosition('topright');
-    this.map.scrollWheelZoom.disable();
-    this.tileLayer = L.tileLayer(BASEMAP_TILE).addTo(this.map).setZIndex(0);
+    this.initMap();
+    this.addShareControl();
 
     if (this.props.data && this.props.data.length) {
       this.drawMarkers(this.props.data);
     }
-    this.setListeners();
   }
 
   componentWillReceiveProps(newProps) {
@@ -57,33 +29,7 @@ class SitesMap extends React.Component {
   }
 
   componentWillUnmount() {
-    this.map.remove();
-    this.unsetListeners();
-  }
-
-  setListeners() {
-    this.map.on('dragend', this.setMapParams.bind(this));
-    this.map.on('zoomend', this.setMapParams.bind(this));
-  }
-
-  getMapParams() {
-    const latLng = this.map.getCenter();
-    return {
-      zoom: this.map.getZoom(),
-      lat: latLng.lat,
-      lng: latLng.lng
-    };
-  }
-
-  setMapParams() {
-    const route = this.props.router.getCurrentLocation();
-    const url = replaceUrlParams(route.pathname + route.search, this.getMapParams());
-    this.props.router.push(url);
-  }
-
-  unsetListeners() {
-    this.map.off('dragend', this.setMapParams.bind(this));
-    this.map.off('zoomend', this.setMapParams.bind(this));
+    this.remove();
   }
 
   drawMarkers(data) {
@@ -120,14 +66,14 @@ class SitesMap extends React.Component {
   }
 
   clearMarkers() {
-    this.markers.clearLayers();
+    if (this.markers) this.markers.clearLayers();
     this.markerList = [];
   }
 
   render() {
     return (
       <div className="l-maps-container">
-        <div id={'map-base'} className="c-map -full"></div>
+        <div id={this.props.id} className="c-map -full"></div>
       </div>
     );
   }

--- a/app/components/sites/SitesMap.js
+++ b/app/components/sites/SitesMap.js
@@ -10,7 +10,6 @@ class SitesMap extends BasicMap {
 
   componentDidMount() {
     this.initMap();
-    this.addShareControl();
 
     if (this.props.data && this.props.data.length) {
       this.drawMarkers(this.props.data);

--- a/app/components/species/SpeciesDetailMap.js
+++ b/app/components/species/SpeciesDetailMap.js
@@ -1,24 +1,13 @@
 import React from 'react';
-import { BASEMAP_TILE, BASEMAP_ATTRIBUTION_MAPBOX, BASEMAP_ATTRIBUTION_CARTO,
-  MAP_MIN_ZOOM, MAP_CENTER, MAP_MAX_BOUNDS } from 'constants/map';
+import { withRouter } from 'react-router';
+import BasicMap from 'components/maps/BasicMap';
+import { BASEMAP_ATTRIBUTION_CARTO } from 'constants/map';
 import { createLayer, getSqlQuery } from 'helpers/map';
 import SpeciesDetailLegend from 'containers/species/SpeciesDetailLegend';
 
-class SpeciesMap extends React.Component {
+class SpeciesMap extends BasicMap {
   componentDidMount() {
-    this.map = L.map('map-base', {
-      minZoom: MAP_MIN_ZOOM,
-      maxBounds: MAP_MAX_BOUNDS,
-      zoom: MAP_MIN_ZOOM,
-      center: MAP_CENTER,
-      detectRetina: true
-    });
-
-    this.map.attributionControl.addAttribution(BASEMAP_ATTRIBUTION_MAPBOX);
-    this.map.zoomControl.setPosition('topright');
-    this.map.scrollWheelZoom.disable();
-    this.tileLayer = L.tileLayer(BASEMAP_TILE).addTo(this.map).setZIndex(0);
-
+    this.initMap();
 
     this.markers = [];
     if (this.props.sites && this.props.sites.length) {
@@ -40,7 +29,7 @@ class SpeciesMap extends React.Component {
   }
 
   componentWillUnmount() {
-    this.map.remove();
+    this.remove();
   }
 
   getBounds(id) {
@@ -157,7 +146,7 @@ class SpeciesMap extends React.Component {
   render() {
     return (
       <div className="l-maps-container">
-        <div id={'map-base'} className="c-map -full"></div>
+        <div id={this.props.id} className="c-map -full"></div>
         <div className="l-legend">
           <SpeciesDetailLegend />
         </div>
@@ -173,9 +162,10 @@ SpeciesMap.contextTypes = {
 
 
 SpeciesMap.propTypes = {
+  router: React.PropTypes.object.isRequired,
   id: React.PropTypes.string.isRequired,
   sites: React.PropTypes.any.isRequired,
   population: React.PropTypes.any.isRequired
 };
 
-export default SpeciesMap;
+export default withRouter(SpeciesMap);

--- a/app/helpers/router.js
+++ b/app/helpers/router.js
@@ -1,0 +1,13 @@
+export function replaceUrlParams(url, params) {
+  let newUrl = url;
+  Object.keys(params).forEach((key) => {
+    const paramVal = params[key] || '';
+    const pattern = new RegExp(`\\b(${key}=).*?(&|$)`);
+    if (newUrl.search(pattern) >= 0) {
+      newUrl = newUrl.replace(pattern, `$1${paramVal}$2`);
+    } else {
+      newUrl += `${(newUrl.indexOf('?') > 0 ? '&' : '?')}${key}=${paramVal}`;
+    }
+  });
+  return newUrl;
+}

--- a/app/styles/components/common/c-share.pcss
+++ b/app/styles/components/common/c-share.pcss
@@ -1,0 +1,79 @@
+$share-btn-size: rem(40);
+
+$share-twitter-color: #6bcfef;
+$share-facebook-color: #4a6da7;
+$share-mail-color: #f45c46;
+
+.c-share {
+  display: flex;
+  flex-direction: column;
+  z-index: 2;
+  min-height: $share-btn-size;
+
+  .share-btn {
+    position: relative;
+    top: 0;
+    width: $share-btn-size;
+    height: $share-btn-size;
+    margin-bottom: -40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.3s ease-in-out;
+    z-index: 2;
+    opacity: 0;
+    border-bottom: 1px solid $bg-dark-color;
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    svg {
+      fill: $white;
+      transition: fill 0.3s ease-in-out;
+    }
+
+    &.-share {
+      z-index: 3;
+      opacity: 1;
+      margin-bottom: 0;
+    }
+
+    &:hover {
+
+      &.-twitter {
+        background-color: $share-twitter-color;
+      }
+
+      &.-facebook {
+        background-color: $share-facebook-color;
+      }
+
+      &.-mail {
+        background-color: $share-mail-color;
+      }
+
+      .icon {
+        fill: $white;
+      }
+    }
+  }
+
+  &:hover {
+
+    .share-btn {
+      opacity: 1;
+
+      &:not(.-share) {
+        margin-bottom: 0;
+      }
+
+      &.-share {
+        margin-top: -40px;
+        opacity: 0;
+        z-index: 1;
+      }
+    }
+  }
+}

--- a/app/styles/components/index.pcss
+++ b/app/styles/components/index.pcss
@@ -21,6 +21,7 @@
 @import "common/c-toggler-view.pcss";
 @import "common/c-infinite-scroll.pcss";
 @import "common/c-switch.pcss";
+@import "common/c-share.pcss";
 
 /* Home */
 @import "home/c-banner.pcss";

--- a/app/styles/components/maps/c-map-controlers.pcss
+++ b/app/styles/components/maps/c-map-controlers.pcss
@@ -1,56 +1,77 @@
-.leaflet-right .leaflet-control {
-  margin: 0;
-}
+.c-map {
+  .leaflet-top.leaflet-right {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    z-index: 1;
 
-.leaflet-control-zoom {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  z-index: 1;
+    .leaflet-control {
+      margin: 10px 0 0;
+      border: none;
+    }
 
-  .-header & {
-    top: rem(85);
+    .-header & {
+      top: rem(85);
+    }
   }
-}
+  .leaflet-top {
+    .-header & {
+      top: rem(85);
+    }
+  }
 
-.leaflet-bar {
-  box-shadow: none;
-  border-radius: 0;
+  .leaflet-bar {
+    box-shadow: none;
+    border-radius: 0;
 
-  a,
-  a:hover {
+    a,
+    a:hover {
+      width: rem(40);
+      height: rem(40);
+      font-size: rem(24);
+      line-height: rem(40);
+      color: $white;
+      background-color: rgba($bg-dark-color, 0.6);
+
+      &:first-child {
+        border: 0;
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+        border-bottom: rem(1) solid $border-color;
+      }
+
+      &:last-child {
+        border: 0;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+
+      &.leaflet-disabled {
+        background-color: rgba($bg-dark-color, 0.6);
+        color: rgba($white, 0.4);
+      }
+    }
+
+    a:hover {
+      background-color: rgba($bg-dark-color, 0.8);
+    }
+  }
+
+  .leaflet-custom-control {
     width: rem(40);
     height: rem(40);
-    padding: rem(6);
     font-size: rem(24);
+    line-height: rem(40);
     color: $white;
     background-color: rgba($bg-dark-color, 0.6);
 
-    &:first-child {
-      border: 0;
-      border-top-left-radius: 0;
-      border-top-right-radius: 0;
-      border-bottom: rem(1) solid $border-color;
-    }
-
-    &:last-child {
-      border: 0;
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0;
-    }
-
-    &.leaflet-disabled {
-      background-color: rgba($bg-dark-color, 0.6);
-      color: rgba($white, 0.4);
+    &.share-control {
+      height: auto;
     }
   }
 
-  a:hover {
-    background-color: rgba($bg-dark-color, 0.8);
+  .leaflet-control-zoom-in,
+  .leaflet-control-zoom-out {
+    /* border: 1px solid $border-color; */
   }
-}
-
-.leaflet-control-zoom-in,
-.leaflet-control-zoom-out {
-  /* border: 1px solid $border-color; */
 }


### PR DESCRIPTION
Now we are able to reuse the map functionality extending the BasicMap to the url synchronisation and share control. By default it will draw a map but we can override the methods ([example](https://github.com/Vizzuality/csn-tool/compare/develop...feature/map-url-params?expand=1#diff-04829429b35901aa4162833d075e4475L42)) for each map.

But now we have two dependencies for the component that will extend it:
- [Id](https://github.com/Vizzuality/csn-tool/compare/develop...feature/map-url-params?expand=1#diff-3ff6111a77cc1eaa4b433c19d110c68bR55) of the map
- [Wrap](https://github.com/Vizzuality/csn-tool/compare/develop...feature/map-url-params?expand=1#diff-2f3895d38550287821a22a587f2de9f3R277) the component [withRouter](https://github.com/ReactTraining/react-router/blob/master/docs/API.md#withroutercomponent-options) HOC (High Order Component) 