### PR TITLE
Replaced true values with tick and added header over "a,b,c"

### DIFF
--- a/app/components/tables/TableList.js
+++ b/app/components/tables/TableList.js
@@ -42,6 +42,20 @@ function TableList(props) {
             } else {
               alignClass = '-left';
             }
+
+            if (typeof item[column] === 'boolean') {
+              const value = item[column] ? (
+                <svg className="icon -small -grey">
+                  <use xlinkHref="#icon-tick"></use>
+                </svg>
+              ) : null;
+              return (
+                <div key={index2} style={{ width: `${colWidth}%` }}>
+                  <div className={`text ${column} ${alignClass}`}>{value}</div>
+                </div>
+              );
+            }
+
             if (['scientific_name', 'site_name'].indexOf(column) >= 0 && item.hyperlink) {
               return (<div key={index2} style={{ width: `${colWidth}%` }}><div className={`text ${column} ${alignClass}`} dangerouslySetInnerHTML={{ __html: item[column] }} ></div>
                 <a className="external-link" target="_blank" href={item.hyperlink}>

--- a/app/styles/components/common/c-table-list.pcss
+++ b/app/styles/components/common/c-table-list.pcss
@@ -35,7 +35,7 @@
         }
 
         .inner-column {
-            padding-right: 0.9375rem;
+          padding-right: 0.9375rem;
         }
       }
 

--- a/app/styles/components/common/c-table-list.pcss
+++ b/app/styles/components/common/c-table-list.pcss
@@ -25,6 +25,18 @@
           display: inline-flex;
           align-items: center;
         }
+
+        .overheader {
+          border-bottom: rem(2) solid $border-color;
+          margin-right: rem(15);
+          padding-bottom: 6px;
+          margin-bottom: 6px;
+          padding-right: 0;
+        }
+
+        .inner-column {
+            padding-right: 0.9375rem;
+        }
       }
 
       &.table-row {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "description": "Critical Sites Network Tool 2.0",
   "main": "server.js",
   "scripts": {
+    "test": "NODE_PATH=./app jest",
+    "test --watch": "NODE_PATH=./app jest --watch",    
     "dev": "./node_modules/nodemon/bin/nodemon.js --ignore 'app/' --exec npm run start",
     "build": "webpack --config ./config/webpack.config.js --progress --profile --colors",
     "postinstall": "npm run build",
@@ -73,13 +75,18 @@
     "webpack-dotenv-plugin": "^1.3.2"
   },
   "devDependencies": {
+    "chai": "^4.0.1",
+    "enzyme": "^2.8.2",
     "eslint": "^2.9.0",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.14.0",
     "eslint-plugin-jsx-a11y": "^1.2.0",
     "eslint-plugin-react": "^5.0.1",
     "husky": "^0.11.7",
+    "jest": "^20.0.4",
     "nodemon": "^1.11.0",
+    "react-addons-test-utils": "^15.5.1",
+    "react-dom": "^15.5.4",
     "stylelint-config-standard": "^13.0.0",
     "webpack-bundle-analyzer": "^1.3.0",
     "webpack-dev-middleware": "^1.6.1"


### PR DESCRIPTION
This includes:

1) the addition of Jest/Enzyme for testing. Tests are included in components/__tests__
2) the replacement of "true" values with ticks - [story](https://www.pivotaltracker.com/story/show/146601927)
3) the addition of a header over "a,b,c" - [story](https://www.pivotaltracker.com/story/show/146602383)

I also included some refactoring of TableListHeader in order to more clearly implement #3. This mainly included dividing the single large render into a series of easier to digest renders. I built #3 in a way that should allow the addition of subsequent superheaders very easily.

All changes are in components/TableList (#2) and components/TableListHeader (#3).

As a side note, the only pages I could find "a,b,c" on were [here](http://csn-tool.herokuapp.com/en/countries/CAN/populations) and [here](http://csn-tool.herokuapp.com/en/countries/CAN/lookAlikeSpecies?zoom=3&lat=71.32314957446724&lng=-96.81261534293428). The first looks very cluttered in the header (and did before my addition). One suggestion might be to automatically limit the number of headers after I add the filter headers tool.

As another side note, while refactoring I had to make sure everything was still working just by visual test. This is one of the reasons I like to start with testing in JavaScript. Makes refactoring so much easier.