### PR TITLE
Fix/table fixes

### DIFF
--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -1,9 +1,8 @@
 const rp = require('request-promise');
 const CARTO_SQL = require('../constants').CARTO_SQL;
 
-async function getCountries() {
+async function getGeneral(query) {
   try {
-    const query = 'SELECT DISTINCT(country) as label, country_id as value FROM countries ORDER by country ASC';
     const data = await rp(CARTO_SQL + query);
     return JSON.parse(data).rows || [];
   } catch (err) {
@@ -11,74 +10,49 @@ async function getCountries() {
   }
 }
 
-async function getSites() {
-  try {
-    const query = 'SELECT DISTINCT(site_name) as label, site_id as value, country_id FROM sites ORDER by site_name ASC';
-    const data = await rp(CARTO_SQL + query);
-    return JSON.parse(data).rows || [];
-  } catch (err) {
-    return [];
+const queryProducer = (table, label, value) => {
+  let formattedLabel = label;
+  if (label === 'eu_birds_directive' || label === 'caf_action_plan') {
+    formattedLabel = `CAST(${label} as CHAR(50))`;
   }
-}
+  return `SELECT DISTINCT(${formattedLabel}) as label, ${value || label} as value FROM ${table} ORDER BY ${label} ASC`;
+};
 
-async function getFamilies() {
-  try {
-    const query = 'SELECT DISTINCT(family) as label, family as value FROM species ORDER by family ASC';
-    const data = await rp(CARTO_SQL + query);
-    return JSON.parse(data).rows || [];
-  } catch (err) {
-    return [];
-  }
-}
-
-async function getGenus() {
-  try {
-    const query = 'SELECT DISTINCT(genus) as label, genus as value FROM species ORDER by genus ASC';
-    const data = await rp(CARTO_SQL + query);
-    return JSON.parse(data).rows || [];
-  } catch (err) {
-    return [];
-  }
-}
-
-async function getSpecies() {
-  try {
-    const query = 'SELECT DISTINCT(scientific_name) as label, species_id as value, family, genus FROM species ORDER by scientific_name ASC';
-    const data = await rp(CARTO_SQL + query);
-    return JSON.parse(data).rows || [];
-  } catch (err) {
-    return [];
-  }
-}
-
-async function getHabitats() {
-  try {
-    const query = 'SELECT DISTINCT(habitat_name) as label, habitat_id as value FROM sites_habitats ORDER by habitat_name ASC';
-    const data = await rp(CARTO_SQL + query);
-    return JSON.parse(data).rows || [];
-  } catch (err) {
-    return [];
-  }
-}
+const optionQueries = [
+  // geography
+  { name: 'country', query: queryProducer('countries', 'country', 'country_id') },
+  { name: 'ramsar_region', query: queryProducer('populations_iba', 'ramsar_criterion_6') },
+  { name: 'aewa_region', query: '' },
+  { name: 'site', query: queryProducer('sites', 'site_name', 'site_id') },
+  { name: 'protection', query: queryProducer('sites', 'protection_status') },
+  { name: 'site_threat', query: '' },
+  { name: 'site_habitat', query: queryProducer('sites_habitats', 'habitat_name', 'habitat_id') },
+  // species attributes
+  { name: 'family', query: queryProducer('species', 'family') },
+  { name: 'genus', query: queryProducer('species', 'genus') },
+  { name: 'species',
+    query: 'SELECT DISTINCT(scientific_name) as label, species_id as value, family, genus FROM species ORDER by scientific_name ASC' },
+  { name: 'red_list_status', query: queryProducer('species_main', 'iucn_category') },
+  { name: 'aewa_annex_2', query: '' },
+  { name: 'species_threat', query: queryProducer('species_threats', 'threat_level_1') },
+  { name: 'species_habitat_association', query: queryProducer('species_habitats', 'habitat_level_1') },
+  // population
+  { name: 'aewa_table_1_status', query: queryProducer('populations_iba', 'a') },
+  { name: 'eu_birds_directive', query: queryProducer('populations_iba', 'eu_birds_directive') },
+  { name: 'cms_caf_action_plan', query: queryProducer('populations_iba', 'caf_action_plan') },
+  { name: 'multispecies_flyway', query: queryProducer('populations_iba', 'flyway_range') },
+  { name: 'population_trend', query: '' }
+];
 
 async function getOptions(req, res) {
   try {
-    const queries = [];
-    queries.push(getCountries());
-    queries.push(getSites());
-    queries.push(getFamilies());
-    queries.push(getGenus());
-    queries.push(getSpecies());
-    queries.push(getHabitats());
+    const queries = optionQueries.map(({ query }) => getGeneral(query));
     const options = await Promise.all(queries);
-    res.json({
-      country: options[0],
-      site: options[1],
-      family: options[2],
-      genus: options[3],
-      species: options[4],
-      habitat: options[5]
+    const queryReturns = {};
+    optionQueries.forEach(({ name }, index) => {
+      queryReturns[name] = options[index];
     });
+    res.json(queryReturns);
   } catch (err) {
     res.status(err.statusCode || 500);
     res.json({ error: err.message });
@@ -105,6 +79,14 @@ async function getSitesResults(req, res) {
   // from req.query['paramName']
   try {
     const params = parseParams(req.query);
+    const where = [];
+    if (params.country) {
+      where.push(`country_id IN(${params.country.join()})`);
+    }
+    if (params.protection) {
+      where.push(`protection_status = '${params.protection}'`);
+    }
+
     const query = `with stc as (select site_id,
       SUM(case when iba_criteria = '' then 0 else 1 end) as iba
       from species_sites group by site_id)
@@ -118,19 +100,16 @@ async function getSitesResults(req, res) {
       , s.site_id AS id
       FROM sites s
       LEFT JOIN stc ON stc.site_id = s.site_id
-      ${params.species || params.genus || params.family
-        ? `JOIN species_sites ss ON ss.site_id = s.site_id
+      ${(params.species || params.genus || params.family) &&
+        `JOIN species_sites ss ON ss.site_id = s.site_id
           JOIN species ON ss.species_id = species.species_id AND (
             ${params.species ? `species.species_id IN(${params.species.join()})` : false}
             OR ${params.genus ? `species.genus IN('${params.genus.join('\',\'')}')` : false}
             OR ${params.family ? `species.family IN('${params.family.join('\',\'')}')` : false}
-          )`
-        : ''}
-      ${params.habitat
-        ? `JOIN sites_habitats sh ON sh.site_id = s.site_id AND habitat_id IN (${params.habitat.join()})`
-        : ''
-      }
-      ${params.country ? `WHERE country_id IN(${params.country.join()})` : ''}
+          )` || ''}
+      ${params.habitat &&
+        `JOIN sites_habitats sh ON sh.site_id = s.site_id AND habitat_id IN (${params.habitat.join()})` || ''}
+      ${where.length > 0 && `WHERE ${where.join(' AND ')}` || ''}
       GROUP BY s.site_name, s.country, s.iso2, s.protection_status, s.hyperlink,
       s.iba_in_danger, s.site_id, stc.iba
       ORDER by country ASC, site_name ASC`;

--- a/api/controllers/sites.js
+++ b/api/controllers/sites.js
@@ -15,7 +15,6 @@ function getSites(req, res) {
     : '';
 
   let query;
-
   if (req.query.filter === 'iba') {
     query = `with stc as (
       select site_id, SUM(case when iba_criteria = '' then 0 else 1

--- a/app/components/countries/CountriesTable.js
+++ b/app/components/countries/CountriesTable.js
@@ -24,6 +24,14 @@ class CountriesTable extends React.Component {
     this.props.cleanSearchFilter('');
   }
 
+  componentWillReceiveProps(newProps) {
+    if (newProps.category !== 'lookAlikeSpecies') {
+      this.setState({
+        selectedItem: null
+      });
+    }
+  }
+
   getLookAlikeSpecies(species) {
     this.setState({
       selectedItem: species

--- a/app/components/pages/AdvancedSearchPage.js
+++ b/app/components/pages/AdvancedSearchPage.js
@@ -10,15 +10,16 @@ import { StickyContainer } from 'react-sticky';
 const rows = [
   {
     title: 'geography',
-    sections: ['country', 'site']
+    sections: ['country', 'aewa_region', 'ramsar_region', 'site', 'protection', 'site_threat', 'site_habitat']
   },
   {
     title: 'taxonomy',
-    sections: ['family', 'genus', 'species']
+    sections: ['family', 'genus', 'species', 'red_list_status', 'aewa_annex_2',
+      'species_threat', 'species_habitat_association']
   },
   {
-    title: 'habitat',
-    sections: ['habitat']
+    title: 'population',
+    sections: ['aewa_table_1_status', 'eu_birds_directive', 'cms_caf_action_plan', 'multispecies_flyway', 'population_trend']
   }
 ];
 

--- a/app/components/species/SpeciesDetailTable.js
+++ b/app/components/species/SpeciesDetailTable.js
@@ -19,6 +19,14 @@ class SpeciesDetailTable extends React.Component {
     this.getLookAlikeSpecies = this.getLookAlikeSpecies.bind(this);
   }
 
+  componentWillReceiveProps(newProps) {
+    if (newProps.category !== 'lookAlikeSpecies') {
+      this.setState({
+        selectedItem: null
+      });
+    }
+  }
+
   getLookAlikeSpecies(species) {
     this.setState({
       selectedItem: species
@@ -76,6 +84,8 @@ class SpeciesDetailTable extends React.Component {
     switch (category) {
       case 'populations':
         return 'species';
+      case 'population':
+        return null; // no display
       case 'criticalSites':
         return 'sites/csn';
       case 'lookAlikeSpecies':

--- a/app/components/species/SpeciesDetailTable.js
+++ b/app/components/species/SpeciesDetailTable.js
@@ -119,7 +119,13 @@ class SpeciesDetailTable extends React.Component {
   renderTableHeader(isLookAlikeSpecies, data, columns, allColumns) {
     return (
       <div>
-        <SpeciesDetailFilters data={data} columns={columns} isSearch={this.props.isSearch} id={this.props.id} category={this.props.category} />
+        <SpeciesDetailFilters
+          data={data}
+          columns={columns}
+          isSearch={this.props.isSearch}
+          id={this.props.id}
+          category={this.props.category}
+        />
         {isLookAlikeSpecies && this.state.selectedItem && this.state.data.length > 0
           ? this.getSelectedHeader()
           : null

--- a/app/components/tables/TableList.js
+++ b/app/components/tables/TableList.js
@@ -5,33 +5,38 @@ import { numberToThousands } from 'helpers/data';
 
 const columnsWithYears = ['year', 'start', 'end', 'year_end', 'year_start'];
 
-function getDetailLink(detailLink, item) {
-  const popupContent = typeof detailLink === 'string' && detailLink.indexOf('species') > -1 ? 'species' : 'sites';
-  if (detailLink && detailLink.type === 'action') {
-    return (
-      <div className="link">
-        <div className="popup">
-          <div className="popup-content">View species details</div>
-          <button className="popup-link" onClick={() => detailLink.action(item)} icon="icon-table_arrow_right" >
-            <svg><use xlinkHref="#icon-table_arrow_right"></use></svg>
-          </button>
-        </div>
-      </div>
-    );
-  }
+function detailLinkFrame(label, link) {
   return (
     <div className="link">
       <div className="popup">
-        <div className="popup-content">View {popupContent} details</div>
-        <NavLink className="popup-link" to={`/${detailLink}/${item.id}`} icon="icon-table_arrow_right" parent />
+        <div className="popup-content">{label}</div>
+        {link}
       </div>
     </div>
   );
 }
 
+function getDetailLink(detailLink, item) {
+  const popupContent = typeof detailLink === 'string' && detailLink.indexOf('species') > -1 ? 'species' : 'sites';
+  if (detailLink && detailLink.type === 'action') {
+    return (
+      detailLinkFrame('View species details', (
+        <button className="popup-link" onClick={() => detailLink.action(item)} icon="icon-table_arrow_right" >
+          <svg><use xlinkHref="#icon-table_arrow_right"></use></svg>
+        </button>
+      ))
+    );
+  }
+  return (
+    detailLinkFrame(`View ${popupContent} details`, (
+      <NavLink className="popup-link" to={`/${detailLink}/${item.id}`} icon="icon-table_arrow_right" parent />
+    ))
+  );
+}
+
 function TableList(props) {
   if (!props.data) return (<div className="c-table-list blank"><LoadingSpinner inner transparent /></div>);
-  const colWidth = props.detailLink ? (97.5 / props.columns.length) : (100 / props.columns.length);
+  const colWidth = 97.5 / props.columns.length; // still need empty category
   const colCenter = ['a', 'b', 'c', 'original_a', 'original_b', 'original_c',
     'iba', 'csn', 'iba_species', 'csn_species'];
   return !props.data.length
@@ -103,9 +108,12 @@ function TableList(props) {
             const colVal = (typeof item[column] === 'number' && columnsWithYears.indexOf(column) === -1) ? numberToThousands(item[column]) : item[column];
             return (<div key={index2} className={`text ${column} ${alignClass}`} style={{ width: `${colWidth}%` }} dangerouslySetInnerHTML={{ __html: colVal }}></div>);
           })}
-
           {props.detailLink &&
-            getDetailLink(props.detailLink, item)
+            getDetailLink(props.detailLink, item) ||
+            <div className="link">
+              <div className="popup">
+              </div>
+            </div>
           }
         </li>
       ))}

--- a/app/components/tables/TableListHeader.js
+++ b/app/components/tables/TableListHeader.js
@@ -136,16 +136,18 @@ class TableListHeader extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     const isNewCategory = this.props.selectedCategory !== nextProps.selectedCategory;
-    const isDataDifferent = nextProps.data.length && this.props.data.length !== nextProps.data.length;
     const areColsDifferent = nextProps.columns.length && this.props.columns.length !== nextProps.columns.length;
 
     if (isNewCategory) {
       this.filterBy({ field: 'all', value: 'reset' });
+      this.hasProducedFilters = false;
     }
 
-    if (!this.hasProducedFilters || (areColsDifferent && isDataDifferent)) {
-      this.filters = getFilters(nextProps.columns, nextProps.data);
-      this.hasProducedFilters = true;
+    if (!this.hasProducedFilters || (areColsDifferent)) {
+      if (nextProps.data.length) {
+        this.filters = getFilters(nextProps.columns, nextProps.data);
+        this.hasProducedFilters = true;
+      }
     }
   }
 

--- a/app/components/threshold/ThresholdMap.js
+++ b/app/components/threshold/ThresholdMap.js
@@ -94,12 +94,13 @@ class ThresholdMap extends BasicMap {
   initPopup() {
     this.popup = L.popup({
       closeButton: false,
-      offset: L.point(0, -3)
+      offset: L.point(0, -3),
+      autoPan: false
     }).setContent('');
   }
 
   showPopup(e) {
-    const html = '<p class="text -light">Click on the map to reveal relevant species</p>';
+    const html = '<p style={{ float: "left"}} class="text -light">Click on the map to reveal relevant species</p>';
 
     this.popup.setLatLng(e.latlng)
       .setContent(html)
@@ -109,10 +110,17 @@ class ThresholdMap extends BasicMap {
   }
 
   setPopupPosition(e) {
-    if (this.popupVisible) {
-      this.popup.setLatLng(e.latlng);
+    const bounds = this.map.getBounds();
+    const totalWidth = (bounds.getEast() - bounds.getWest());
+    const noFlyWidth = totalWidth / 10;
+    if (e.latlng.lng > (bounds.getEast() - noFlyWidth) || e.latlng.lng < (bounds.getWest() + noFlyWidth)) {
+      if (this.popupVisible) this.hidePopup();
     } else {
-      this.showPopup(e);
+      if (this.popupVisible) {
+        this.popup.setLatLng(e.latlng);
+      } else {
+        this.showPopup(e);
+      }
     }
   }
 

--- a/app/locales/translations.js
+++ b/app/locales/translations.js
@@ -104,7 +104,21 @@ export const translations = {
     'geography': 'Geography',
     'taxonomy': 'Taxonomy',
     'habitat': 'Habitat',
-    'selectOneOption': 'Select at least one option'
+    'selectOneOption': 'Select at least one option',
+    'ramsar_region': 'Ramsar region',
+    'aewa_region': 'AEWA region',
+    'protection': 'Protection',
+    'site_threat': 'Site threat',
+    'site_habitat': 'Site habitat',
+    'red_list_status': 'Red list status',
+    'aewa_annex_2': 'AEWA annex 2',
+    'species_threat': 'Species threat',
+    'species_habitat_association': 'Species habitat association',
+    'aewa_table_1_status': 'AEWA table 1 status',
+    'eu_birds_directive': 'EU birds directive',
+    'cms_caf_action_plan': 'CMS CAF action plan',
+    'multispecies_flyway': 'Multispecies flyway',
+    'population_trend': 'Population trend'
   },
   es: {
     'country': 'Pais',

--- a/app/styles/components/common/c-forms.pcss
+++ b/app/styles/components/common/c-forms.pcss
@@ -1,6 +1,6 @@
 .c-search-group {
   border-bottom: 1px solid rgba($bg-dark-color, 0.2);
-  padding: rem(28) 0;
+  padding: rem(28) 0 0;
 
   .group-title {
     margin-bottom: rem(14);
@@ -10,11 +10,14 @@
   }
 
   .group-field {
+    padding-bottom: rem(28);
+
     > .label {
-      margin-bottom: rem(7);
-      font-size: $font-size-xs;
+      margin-bottom: rem(3);
+      font-size: $font-size-xxs;
       font-family: $font-body;
       font-weight: 500;
+      text-transform: uppercase;
     }
   }
 }


### PR DESCRIPTION
Includes:

1. Remove detail link from tables that don't require it - [story](https://www.pivotaltracker.com/story/show/147452869) - [link](http://csn-tool.herokuapp.com/en/species/22679814/population)
2. Look alike details page "sticks" when moving to another species page from there. - [story](https://www.pivotaltracker.com/story/show/147453039) - [link](http://csn-tool.herokuapp.com/en/species/22679839/lookAlikeSpecies)
3. Look Alikes' details page filters and sorting not enabled. - [story](https://www.pivotaltracker.com/story/show/147453139) - [link](http://csn-tool.herokuapp.com/en/countries/CAN/populations)
  *Was actually issue switching between any tabs
4. When on the Threshold Look Up Tool the tooltip on the map makes the map hover when nearing the borders of the map - [story](https://www.pivotaltracker.com/story/show/147455115) - [link](http://csn-tool.herokuapp.com/en/threshold-lookup)
  *Solved this two ways. 1) Disabled panning with the tooltip (which is what I thought you wanted) 2) Tooltip disappears when cursor gets near edge of screen.