### PR TITLE
Replaces hard coded text with I18n calls.

### DIFF
--- a/app/components/common/Feedback.js
+++ b/app/components/common/Feedback.js
@@ -1,6 +1,7 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-function Feedback() {
+function Feedback(props, context) {
   return (
     <a
       className="typeform-share"
@@ -8,8 +9,13 @@ function Feedback() {
       data-mode="popup"
       target="_blank"
     >
-      Feedback
+      {context.t('feedback')}
     </a>
   );
 }
+
+Feedback.contextTypes = {
+  t: PropTypes.func.isRequired
+};
+
 export default Feedback;

--- a/app/components/common/ScrollButton.js
+++ b/app/components/common/ScrollButton.js
@@ -85,13 +85,17 @@ class ScrollButton extends React.Component {
     return (
       <div className={`c-scroll-button ${this.state.showLabel ? '' : '-hide'} ${this.state.fixed ? '-fixed' : ''}`} ref={(ref) => { this.scrollContainer = ref; }}>
         <div className="button" onClick={this.handleClick}>
-          <svg width="18" height="11" viewBox="0 0 18 11"><title>Scroll down</title><path d="M1.641-.044l7.27 7.278 7.374-7.241L17.823 1.5 8.91 10.411 0 1.5z" fillRule="evenodd" /></svg>
+          <svg width="18" height="11" viewBox="0 0 18 11"><title>{this.context.t('scrollText')}</title><path d="M1.641-.044l7.27 7.278 7.374-7.241L17.823 1.5 8.91 10.411 0 1.5z" fillRule="evenodd" /></svg>
         </div>
-        <div className="label"><span>Scroll down to see the data</span></div>
+        <div className="label"><span>{this.context.t('scrollText')}</span></div>
       </div>
     );
   }
 }
+
+ScrollButton.contextTypes = {
+  t: PropTypes.func.isRequired
+};
 
 ScrollButton.defaultProps = {
   threshold: 30

--- a/app/components/pages/CountriesPage.js
+++ b/app/components/pages/CountriesPage.js
@@ -59,8 +59,8 @@ class CountriesPage extends React.Component {
                   </div>
                   <div className="filter">
                     <CountriesSearch
-                      placeholder="countriesNameSearch"
-                      label="searchBy"
+                      placeholder={this.context.t('countriesNameSearch')}
+                      label={this.context.t('searchBy')}
                       labelType="light"
                       searchType="dark"
                     />

--- a/app/components/threshold/ThresholdFilters.js
+++ b/app/components/threshold/ThresholdFilters.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import CSVButton from 'components/tables/CSVButton.js';
 import ThresholdSearch from 'containers/threshold/ThresholdSearch';
 
-function TresholdFilters(props) {
+function ThresholdFilters(props, context) {
   return (
     <div className="row c-table-filters">
       <div className="column small-12 medium-8">
-        <h2>{this.context.t('ramsarCriterionToolFilterHeader')}
+        <h2>{context.t('ramsarCriterionToolFilterHeader')}
           <CSVButton data={props.data} columns={props.columns} />
         </h2>
       </div>
@@ -18,9 +18,13 @@ function TresholdFilters(props) {
   );
 }
 
-TresholdFilters.propTypes = {
+ThresholdFilters.contextTypes = {
+  t: PropTypes.func.isRequired
+};
+
+ThresholdFilters.propTypes = {
   data: PropTypes.array.isRequired,
   columns: PropTypes.array.isRequired
 };
 
-export default TresholdFilters;
+export default ThresholdFilters;

--- a/app/components/threshold/ThresholdFilters.js
+++ b/app/components/threshold/ThresholdFilters.js
@@ -7,7 +7,7 @@ function TresholdFilters(props) {
   return (
     <div className="row c-table-filters">
       <div className="column small-12 medium-8">
-        <h2>Relevant Populations
+        <h2>{this.context.t('ramsarCriterionToolFilterHeader')}
           <CSVButton data={props.data} columns={props.columns} />
         </h2>
       </div>

--- a/app/components/threshold/ThresholdMap.js
+++ b/app/components/threshold/ThresholdMap.js
@@ -101,7 +101,7 @@ class ThresholdMap extends BasicMap {
   }
 
   showPopup(e) {
-    const html = '<p style={{ float: "left"}} class="text -light">Click on the map to reveal relevant species</p>';
+    const html = `<p style="float: 'left'" class="text -light">${this.context.t('ramsarCriterionTooltip')}</p>`;
 
     this.popup.setLatLng(e.latlng)
       .setContent(html)
@@ -137,6 +137,10 @@ class ThresholdMap extends BasicMap {
       </div>
     );
   }
+}
+
+ThresholdMap.contextTypes = {
+  t: PropTypes.func.isRequired
 }
 
 ThresholdMap.propTypes = {

--- a/app/components/threshold/ThresholdMap.js
+++ b/app/components/threshold/ThresholdMap.js
@@ -141,7 +141,7 @@ class ThresholdMap extends BasicMap {
 
 ThresholdMap.contextTypes = {
   t: PropTypes.func.isRequired
-}
+};
 
 ThresholdMap.propTypes = {
   coordinates: PropTypes.object

--- a/app/components/threshold/ThresholdTable.js
+++ b/app/components/threshold/ThresholdTable.js
@@ -31,6 +31,10 @@ function ThresholdTable(props) {
   );
 }
 
+ThresholdTable.contextTypes = {
+  t: PropTypes.func.isRequired
+};
+
 ThresholdTable.propTypes = {
   allColumns: PropTypes.array.isRequired,
   data: PropTypes.array.isRequired,

--- a/app/locales/translations.js
+++ b/app/locales/translations.js
@@ -125,7 +125,8 @@ export const translations = {
     'cms_caf_action_plan': 'CMS CAF action plan',
     'multispecies_flyway': 'Multispecies flyway',
     'population_trend': 'Population trend',
-    'tools': 'Tools'
+    'tools': 'Tools',
+    'feedback': 'Feedback'
   },
   es: {
     'country': 'Pais',
@@ -198,6 +199,7 @@ export const translations = {
     'total_percentage': 'Total %',
     'ramsarCriterionTool': 'Ramsar Criterion 6',
     'ramsarCriterionToolTitle': 'Ramsar Criterion 6 Thresholds',
+    'ramsarCriterionToolFilterHeader': 'Relevant Populations',
     'habitats': 'Hábitats',
     'habitat_name': 'Nombre del habitat',
     'habitat_level_1': 'Nivel de hábitat 1',
@@ -237,7 +239,8 @@ export const translations = {
     'taxonomy': 'Taxonomia',
     'habitat': 'Habitat',
     'selectOneOption': 'Selecciona al menos una opción',
-    'tools': 'Herramientas'
+    'tools': 'Herramientas',
+    'feedback': 'Comentarios'
   },
   fr: {
     'country': 'Pays',
@@ -310,6 +313,7 @@ export const translations = {
     'total_percentage': '% Total',
     'ramsarCriterionTool': 'Critère 6 de Ramsar',
     'ramsarCriterionToolTitle': 'Seuils selon Critère 6 Ramsar',
+    'ramsarCriterionToolFilterHeader': 'Populations pertinentes',
     'habitats': 'Habitats',
     'habitat_name': "Nom de l'habitat",
     'habitat_level_1': "Habitat niveau 1",
@@ -366,6 +370,7 @@ export const translations = {
     'cms_caf_action_plan': "Plan d'action CMS CAF",
     'multispecies_flyway': 'Voie de migration plurispécifique',
     'population_trend': 'Tendance de la population',
-    'tools': 'Outils'
+    'tools': 'Outils',
+    'feedback': 'Commentaires'
   },
 }

--- a/app/locales/translations.js
+++ b/app/locales/translations.js
@@ -129,7 +129,8 @@ export const translations = {
     'population_trend': 'Population trend',
     'tools': 'Tools',
     'feedback': 'Feedback',
-    'scrollText': 'Scroll down to see the data'
+    'scrollText': 'Scroll down to see the data',
+    'coordinates': 'Coordinates'
   },
   es: {
     'country': 'Pais',
@@ -245,7 +246,8 @@ export const translations = {
     'selectOneOption': 'Selecciona al menos una opción',
     'tools': 'Herramientas',
     'feedback': 'Comentarios',
-    'scrollText': 'Desplácese hacia abajo para ver los datos'
+    'scrollText': 'Desplácese hacia abajo para ver los datos',
+    'coordinates': 'Coordenadas'
   },
   fr: {
     'country': 'Pays',
@@ -378,6 +380,7 @@ export const translations = {
     'population_trend': 'Tendance de la population',
     'tools': 'Outils',
     'feedback': 'Commentaires',
-    'scrollText': 'Faites défiler vers le bas pour voir les données'
+    'scrollText': 'Faites défiler vers le bas pour voir les données',
+    'coordinates': 'Coordonnées'
   },
 }

--- a/app/locales/translations.js
+++ b/app/locales/translations.js
@@ -69,6 +69,8 @@ export const translations = {
     'total_percentage': 'Total %',
     'ramsarCriterionTool': 'Ramsar Criterion 6',
     'ramsarCriterionToolTitle': 'Ramsar Criterion 6 Thresholds',
+    'ramsarCriterionToolFilterHeader': 'Relevant Populations',
+    'ramsarCriterionTooltip': 'Click on the map to reveal relevant populations',
     'habitats': 'Habitats',
     'habitat_name': 'Habitat name',
     'habitat_level_1': 'Habitat level 1',
@@ -126,7 +128,8 @@ export const translations = {
     'multispecies_flyway': 'Multispecies flyway',
     'population_trend': 'Population trend',
     'tools': 'Tools',
-    'feedback': 'Feedback'
+    'feedback': 'Feedback',
+    'scrollText': 'Scroll down to see the data'
   },
   es: {
     'country': 'Pais',
@@ -199,7 +202,8 @@ export const translations = {
     'total_percentage': 'Total %',
     'ramsarCriterionTool': 'Ramsar Criterion 6',
     'ramsarCriterionToolTitle': 'Ramsar Criterion 6 Thresholds',
-    'ramsarCriterionToolFilterHeader': 'Relevant Populations',
+    'ramsarCriterionToolFilterHeader': 'Poblaciones relevantes',
+    'ramsarCriterionTooltip': 'Haga clic en el mapa para revelar poblaciones relevantes',
     'habitats': 'Hábitats',
     'habitat_name': 'Nombre del habitat',
     'habitat_level_1': 'Nivel de hábitat 1',
@@ -240,7 +244,8 @@ export const translations = {
     'habitat': 'Habitat',
     'selectOneOption': 'Selecciona al menos una opción',
     'tools': 'Herramientas',
-    'feedback': 'Comentarios'
+    'feedback': 'Comentarios',
+    'scrollText': 'Desplácese hacia abajo para ver los datos'
   },
   fr: {
     'country': 'Pays',
@@ -314,6 +319,7 @@ export const translations = {
     'ramsarCriterionTool': 'Critère 6 de Ramsar',
     'ramsarCriterionToolTitle': 'Seuils selon Critère 6 Ramsar',
     'ramsarCriterionToolFilterHeader': 'Populations pertinentes',
+    'ramsarCriterionTooltip': 'Cliquez sur la carte pour révéler les espèces pertinentes',
     'habitats': 'Habitats',
     'habitat_name': "Nom de l'habitat",
     'habitat_level_1': "Habitat niveau 1",
@@ -371,6 +377,7 @@ export const translations = {
     'multispecies_flyway': 'Voie de migration plurispécifique',
     'population_trend': 'Tendance de la population',
     'tools': 'Outils',
-    'feedback': 'Commentaires'
+    'feedback': 'Commentaires',
+    'scrollText': 'Faites défiler vers le bas pour voir les données'
   },
 }


### PR DESCRIPTION
## Overview

This PR removes some hardcoded text and replaces it with calls to the I18n library. I had to add some bits of code to enable this in some of the functions and components. React is not my speciality so I might've done something wrong. Hope not! =)

Examples where text was replaced are in:

- feedback pane throughout;
- Ramsar Criterion 6 tool (under tools);
- Pages with maps and data where there's a scroll button with a label.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] PR has a description that explains it
- [x] PR includes information for people to test it [e.g.: run `npm install`]
- [x] PR is not 2k commits long... please. :pray:

