### PR TITLE
Fix/performance population boundaries render

### DIFF
--- a/app/components/species/SpeciesDetailMap.js
+++ b/app/components/species/SpeciesDetailMap.js
@@ -55,11 +55,11 @@ class SpeciesMap extends BasicMap {
       }
 
       if (this.popBoundaryLayers.length &&
-          (this.props.activeBounds !== newProps.activeBounds || newProps.population)) {
+          (this.props.selectedPopulationBoundaryId !== newProps.selectedPopulationBoundaryId || newProps.population)) {
         this.popBoundaryLayers.forEach((pbLayerGroup) => {
-          const isActive = newProps.activeBounds.some(
-            (bound) => bound.id === pbLayerGroup.options.id && bound.active
-          );
+          const id = pbLayerGroup.options.id;
+          const isActive = id === newProps.selectedPopulationBoundaryId;
+
           pbLayerGroup.setStyle({
             fill: isActive,
             opacity: 1
@@ -114,12 +114,12 @@ class SpeciesMap extends BasicMap {
 
     if (this.props.population) {
       this.props.population.forEach((pop) => {
-        this.getPopulationBoundaryLayer(this.props.id, pop.wpepopid);
+        this.fetchPopulationBoundaryLayer(this.props.id, pop.wpepopid);
       });
     }
   }
 
-  getPopulationBoundaryLayer(id, popId) {
+  fetchPopulationBoundaryLayer(id, popId) {
     const query = `
       SELECT the_geom
       FROM species_and_flywaygroups
@@ -222,7 +222,8 @@ SpeciesMap.propTypes = {
   sites: PropTypes.any.isRequired,
   criticalSites: PropTypes.any.isRequired,
   population: PropTypes.any.isRequired,
-  selectedCategory: PropTypes.string.isRequired
+  selectedCategory: PropTypes.string.isRequired,
+  selectedPopulationBoundaryId: PropTypes.number
 };
 
 export default withRouter(SpeciesMap);

--- a/app/constants/map.js
+++ b/app/constants/map.js
@@ -17,5 +17,4 @@ export const BASEMAP_ATTRIBUTION_MAPBOX = '© <a href="https://www.mapbox.com/ab
 export const BASEMAP_ATTRIBUTION_CARTO = 'CARTO <a href="https://carto.com/attributions" target="_blank">attribution</a>';
 
 // Map's endpoints
-export const ENDPOINT_TILES = `https://${process.env.CARTODB_ACCOUNT}.carto.com/api/v1/map/`;
 export const ENDPOINT_SQL = `https://${process.env.CARTODB_ACCOUNT}.carto.com/api/v2/sql?q=`;

--- a/app/containers/species/SpeciesDetailLegend.js
+++ b/app/containers/species/SpeciesDetailLegend.js
@@ -28,7 +28,7 @@ function getLegendData(species, ownProps) {
           icon: 'dots',
           id: pop.wpepopid,
           name: pop.population,
-          color: ownProps.boundaryColorsToPop[pop.wpepopid]
+          color: ownProps.populationColors[pop.wpepopid]
         });
       });
     }

--- a/app/containers/species/SpeciesDetailMap.js
+++ b/app/containers/species/SpeciesDetailMap.js
@@ -6,7 +6,7 @@ const mapStateToProps = (state) => ({
   sites: state.species.sites[state.species.selected] || false,
   criticalSites: state.species.criticalSites[state.species.selected] || false,
   population: state.species.population[state.species.selected] || false,
-  activeBounds: state.species.activeBounds,
+  selectedPopulationBoundaryId: state.species.selectedPopulationBoundaryId,
   layers: state.species.layers,
   selectedCategory: state.species.selectedCategory
 });

--- a/app/containers/species/SpeciesDetailMap.js
+++ b/app/containers/species/SpeciesDetailMap.js
@@ -6,7 +6,7 @@ const mapStateToProps = (state) => ({
   sites: state.species.sites[state.species.selected] || false,
   criticalSites: state.species.criticalSites[state.species.selected] || false,
   population: state.species.population[state.species.selected] || false,
-  selectedPopulationBoundaryId: state.species.selectedPopulationBoundaryId,
+  selectedPopulationId: state.species.selectedPopulationId,
   layers: state.species.layers,
   selectedCategory: state.species.selectedCategory
 });

--- a/app/helpers/map.js
+++ b/app/helpers/map.js
@@ -1,47 +1,5 @@
-import { ENDPOINT_TILES, ENDPOINT_SQL } from 'constants/map';
+import { ENDPOINT_SQL } from 'constants/map';
 
-// Layer spec
-const MAP_LAYER_SPEC = {
-  layers: [{
-    user_name: process.env.CARTODB_ACCOUNT,
-    type: 'cartodb',
-    options: {
-      sql: '',
-      cartocss: '',
-      cartocss_version: '2.3.0'
-    }
-  }]
-};
-
-function getLayerSpec(layerData) {
-  const spec = Object.assign({}, MAP_LAYER_SPEC);
-  const layerOptions = spec.layers[0].options;
-
-  layerOptions.sql = layerData.sql;
-  layerOptions.cartocss = layerData.cartocss;
-
-  return JSON.stringify(spec);
-}
-
-export function createLayer(layerData, callback) {
-  const layer = getLayerSpec(layerData);
-
-  return fetch(ENDPOINT_TILES, {
-    method: 'POST',
-    body: layer,
-    headers: {
-      'Content-Type': 'application/json; charset=UTF-8'
-    }
-  }).then(response => response.json())
-    .then(res => {
-      callback(`${ENDPOINT_TILES}${res.layergroupid}/{z}/{x}/{y}@2x.png32`);
-    });
-}
-
-export function getSqlQuery(query, callback) {
-  return fetch(ENDPOINT_SQL + query)
-    .then(response => response.json())
-    .then(res => {
-      callback(res.rows);
-    });
+export function getSqlQuery(query) {
+  return fetch(ENDPOINT_SQL + query).then(res => res.json());
 }

--- a/app/reducers/__tests__/species.test.js
+++ b/app/reducers/__tests__/species.test.js
@@ -3,7 +3,6 @@ import reducer from 'reducers/species';
 import { CHANGE_COLUMN_ACTIVATION } from 'constants/index.js';
 
 const initialState = {
-  activeBounds: [],
   allColumns: ['scientific_name', 'english_name', 'genus', 'family', 'iucn_category', 'aewa_annex_2'],
   columns: ['scientific_name', 'genus', 'family', 'iucn_category', 'aewa_annex_2'],
   expandedColumns: ['scientific_name', 'population', 'a', 'b', 'c'],
@@ -11,6 +10,7 @@ const initialState = {
   list: false,
   selected: '',
   selectedCategory: 'sites',
+  selectedPopulationBoundaryId: null,
   searchFilter: '',
   stats: {},
   sites: {},

--- a/app/reducers/__tests__/species.test.js
+++ b/app/reducers/__tests__/species.test.js
@@ -10,7 +10,7 @@ const initialState = {
   list: false,
   selected: '',
   selectedCategory: 'sites',
-  selectedPopulationBoundaryId: null,
+  selectedPopulationId: null,
   searchFilter: '',
   stats: {},
   sites: {},

--- a/app/reducers/species.js
+++ b/app/reducers/species.js
@@ -45,7 +45,6 @@ const initialState = {
   criticalSites: {},
   population: {},
   lookAlikeSpecies: {},
-  activeBounds: [],
   layers: {
     sites: true,
     population: true
@@ -54,6 +53,7 @@ const initialState = {
     field: '',
     order: ''
   },
+  selectedPopulationBoundaryId: null,
   columnFilter: {}
 };
 
@@ -135,23 +135,17 @@ export default function (state = initialState, action) {
       return Object.assign({}, state, { layers });
     }
     case TOGGLE_LEGEND_ITEM: {
-      const activeBounds = state.activeBounds.slice(0);
-      const id = action.payload.id;
-      const active = action.payload.active;
+      const {
+        id,
+        active
+      } = action.payload;
 
-      const foundBound = activeBounds.filter((bound) => bound.id === id)[0];
-      if (!foundBound) {
-        activeBounds.push({ id, active });
-      }
+      const selectedPopulationBoundaryId = active ? id : null;
 
-      const newState = Object.assign({}, state, {
-        activeBounds: activeBounds.map((bound) =>
-          Object.assign({}, bound, {
-            active: (bound.id === id) && active
-          })
-      ) });
-
-      return newState;
+      return {
+        ...state,
+        selectedPopulationBoundaryId
+      };
     }
     case SET_SPECIES_SORT: {
       let list = null;

--- a/app/reducers/species.js
+++ b/app/reducers/species.js
@@ -53,7 +53,7 @@ const initialState = {
     field: '',
     order: ''
   },
-  selectedPopulationBoundaryId: null,
+  selectedPopulationId: null,
   columnFilter: {}
 };
 
@@ -135,16 +135,9 @@ export default function (state = initialState, action) {
       return Object.assign({}, state, { layers });
     }
     case TOGGLE_LEGEND_ITEM: {
-      const {
-        id,
-        active
-      } = action.payload;
-
-      const selectedPopulationBoundaryId = active ? id : null;
-
       return {
         ...state,
-        selectedPopulationBoundaryId
+        selectedPopulationId: action.payload.active ? action.payload.id : null
       };
     }
     case SET_SPECIES_SORT: {


### PR DESCRIPTION
## Overview

Instead of loading map tiles from cartoDB, we will be fetching population's polygons to create GeoJSON leaflet layers which are just basic SVG paths. That should dramatically improve the performance.

**[Story link](https://www.pivotaltracker.com/story/show/153413772)**

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] PR has a description that explains it
- [x] PR includes information for people to test it [e.g.: run `npm install`]
- [x] PR is not 2k commits long... please. :pray:

