### PR TITLE
Feature/Select population on map when selecting look-alike species

### DIFF
--- a/app/actions/species.js
+++ b/app/actions/species.js
@@ -1,8 +1,19 @@
-import { GET_SPECIES_STATS, GET_SPECIES_LIST, GET_SPECIES_SITES,
-  GET_SPECIES_CRITICAL_SITES, GET_SPECIES_POPULATION,
-  GET_SPECIES_LOOK_ALIKE_SPECIES, SET_SPECIES_PARAMS,
-  SET_SPECIES_DETAIL_PARAMS, SET_SPECIES_SORT, SET_SPECIES_COLUMN_FILTER,
-  SET_SPECIES_DETAIL_SEARCH, TOGGLE_SPECIES_LAYER, TOGGLE_LEGEND_ITEM } from 'constants/index.js';
+import {
+  GET_SPECIES_CRITICAL_SITES,
+  GET_SPECIES_LIST,
+  GET_SPECIES_LOOK_ALIKE_SPECIES,
+  GET_SPECIES_POPULATION,
+  GET_SPECIES_SITES,
+  GET_SPECIES_STATS,
+  MAP_SELECT_POPULATION,
+  SET_SPECIES_COLUMN_FILTER,
+  SET_SPECIES_DETAIL_PARAMS,
+  SET_SPECIES_DETAIL_SEARCH,
+  SET_SPECIES_PARAMS,
+  SET_SPECIES_SORT,
+  TOGGLE_LEGEND_ITEM,
+  TOGGLE_SPECIES_LAYER
+} from 'constants/index.js';
 
 export function getSpeciesStats(id) {
   const url = `${config.apiHost}/species/${id}`;
@@ -178,5 +189,12 @@ export function setSpeciesFilter(filter) {
   return {
     type: SET_SPECIES_COLUMN_FILTER,
     payload: filter
+  };
+}
+
+export function mapSelectPopulation(populationId) {
+  return {
+    type: MAP_SELECT_POPULATION,
+    payload: { populationId }
   };
 }

--- a/app/components/species/SpeciesDetailMap.js
+++ b/app/components/species/SpeciesDetailMap.js
@@ -54,7 +54,9 @@ class SpeciesMap extends BasicMap {
       }
 
       if (this.populationLayers.length &&
-          (this.props.selectedPopulationId !== newProps.selectedPopulationId || newProps.population)) {
+          (this.props.selectedPopulationId !== newProps.selectedPopulationId ||
+           this.props.layers.population !== newProps.layers.population ||
+           this.props.population !== newProps.population)) {
         this.populationLayers.forEach((layer) => {
           const id = layer.options.populationId;
           const isActive = id === newProps.selectedPopulationId;
@@ -63,6 +65,10 @@ class SpeciesMap extends BasicMap {
             fill: isActive,
             opacity: 1
           });
+
+          if (isActive && newProps.fitBoundsToSelectedPopulation) {
+            this.map.fitBounds(layer.getBounds());
+          }
         });
       }
     }
@@ -220,7 +226,8 @@ SpeciesMap.propTypes = {
   criticalSites: PropTypes.any.isRequired,
   population: PropTypes.any.isRequired,
   selectedCategory: PropTypes.string.isRequired,
-  selectedPopulationId: PropTypes.number
+  selectedPopulationId: PropTypes.number,
+  fitBoundsToSelectedPopulation: PropTypes.bool
 };
 
 export default withRouter(SpeciesMap);

--- a/app/components/species/SpeciesDetailTable.js
+++ b/app/components/species/SpeciesDetailTable.js
@@ -27,12 +27,12 @@ class SpeciesDetailTable extends React.Component {
   }
 
   getLookAlikeSpecies(species) {
+    const url = `${config.apiHost}/species/${species.species_id}/look-alike-species/${species.pop_id_origin}`;
+
     this.setState({
       selectedItem: species
     });
-    // change the params to the species!
-    // const url = `${config.apiHost}/countries/${species.species_id}/look-alike-species/${species.confusion_species}`;
-    const url = `${config.apiHost}/species/${species.species_id}/look-alike-species/${species.pop_id_origin}`;
+    this.props.mapSelectPopulation(species.pop_id_origin);
 
     fetch(url)
       .then(res => {
@@ -113,6 +113,7 @@ class SpeciesDetailTable extends React.Component {
       data: [],
       selectedItem: null
     });
+    this.props.mapSelectPopulation(null);
   }
 
   renderTableHeader(isLookAlikeSpecies, data, columns, allColumns) {
@@ -184,7 +185,8 @@ SpeciesDetailTable.propTypes = {
   category: PropTypes.string.isRequired,
   data: PropTypes.any.isRequired,
   columns: PropTypes.array.isRequired,
-  expandedColumns: PropTypes.array.isRequired
+  expandedColumns: PropTypes.array.isRequired,
+  mapSelectPopulation: PropTypes.func.isRequired
 };
 
 export default SpeciesDetailTable;

--- a/app/constants/index.js
+++ b/app/constants/index.js
@@ -55,6 +55,7 @@ export const BOUNDARY_COLORS = [
   '#6a3d9a',
   '#ffff99'
 ];
+export const MAP_SELECT_POPULATION = 'MAP_SELECT_POPULATION';
 
 // THRESHOLD
 export const SET_THRESHOLD_DATA = 'SET_THRESHOLD_DATA';

--- a/app/containers/species/SpeciesDetailMap.js
+++ b/app/containers/species/SpeciesDetailMap.js
@@ -6,7 +6,8 @@ const mapStateToProps = (state) => ({
   sites: state.species.sites[state.species.selected] || false,
   criticalSites: state.species.criticalSites[state.species.selected] || false,
   population: state.species.population[state.species.selected] || false,
-  selectedPopulationId: state.species.selectedPopulationId,
+  selectedPopulationId: state.species.highlightedPopulationId || state.species.selectedPopulationId,
+  fitBoundsToSelectedPopulation: !!(!state.species.highlightedPopulationId && state.species.selectedPopulationId),
   layers: state.species.layers,
   selectedCategory: state.species.selectedCategory
 });

--- a/app/containers/species/SpeciesDetailTable.js
+++ b/app/containers/species/SpeciesDetailTable.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import SpeciesDetailTable from 'components/species/SpeciesDetailTable';
 import { filterByColumns, filterBySearch } from 'helpers/filters';
+import { mapSelectPopulation } from 'actions/species';
 
 function getSpeciesDetailData(rows, columns, filter, columnFilter) {
   if (!rows || rows.length === 0) return [];
@@ -48,6 +49,8 @@ const mapStateToProps = (state) => {
   };
 };
 
-const mapDispatchToProps = () => ({});
+const mapDispatchToProps = {
+  mapSelectPopulation
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(SpeciesDetailTable);

--- a/app/reducers/species.js
+++ b/app/reducers/species.js
@@ -1,8 +1,20 @@
-import { GET_SPECIES_STATS, GET_SPECIES_LIST, GET_SPECIES_SITES, GET_SPECIES_POPULATION,
-  GET_SPECIES_CRITICAL_SITES, GET_SPECIES_LOOK_ALIKE_SPECIES, SET_SPECIES_PARAMS,
-  TOGGLE_LEGEND_ITEM, SET_SPECIES_DETAIL_PARAMS, SET_SPECIES_SORT,
-  SET_SPECIES_COLUMN_FILTER, SET_SPECIES_DETAIL_SEARCH, TOGGLE_SPECIES_LAYER,
-  CHANGE_COLUMN_ACTIVATION } from 'constants/index.js';
+import {
+  CHANGE_COLUMN_ACTIVATION,
+  GET_SPECIES_CRITICAL_SITES,
+  GET_SPECIES_LIST,
+  GET_SPECIES_LOOK_ALIKE_SPECIES,
+  GET_SPECIES_POPULATION,
+  GET_SPECIES_SITES,
+  GET_SPECIES_STATS,
+  MAP_SELECT_POPULATION,
+  SET_SPECIES_COLUMN_FILTER,
+  SET_SPECIES_DETAIL_PARAMS,
+  SET_SPECIES_DETAIL_SEARCH,
+  SET_SPECIES_PARAMS,
+  SET_SPECIES_SORT,
+  TOGGLE_LEGEND_ITEM,
+  TOGGLE_SPECIES_LAYER
+} from 'constants/index.js';
 import { commonSort } from './common.js';
 
 const ALL_SPECIES_COLUMNS = {
@@ -54,6 +66,7 @@ const initialState = {
     order: ''
   },
   selectedPopulationId: null,
+  highlightedPopulationId: null,
   columnFilter: {}
 };
 
@@ -73,7 +86,8 @@ export default function (state = initialState, action) {
         selected: action.payload.id,
         selectedCategory: action.payload.category,
         columns: DEFAULT_SPECIES_COLUMNS[action.payload.category],
-        allColumns: ALL_SPECIES_COLUMNS[action.payload.category]
+        allColumns: ALL_SPECIES_COLUMNS[action.payload.category],
+        selectedPopulationId: action.payload.category === 'lookAlikeSpecies' ? state.selectedPopulationId : null
       };
       return Object.assign({}, state, params);
     }
@@ -129,6 +143,12 @@ export default function (state = initialState, action) {
       data[action.payload.id] = action.payload.data;
       return Object.assign({}, state, { lookAlikeSpecies: data });
     }
+    case MAP_SELECT_POPULATION: {
+      return {
+        ...state,
+        selectedPopulationId: action.payload.populationId
+      };
+    }
     case TOGGLE_SPECIES_LAYER: {
       const layers = Object.assign({}, state.layers);
       layers[action.payload] = !layers[action.payload];
@@ -137,7 +157,7 @@ export default function (state = initialState, action) {
     case TOGGLE_LEGEND_ITEM: {
       return {
         ...state,
-        selectedPopulationId: action.payload.active ? action.payload.id : null
+        highlightedPopulationId: action.payload.active ? action.payload.id : null
       };
     }
     case SET_SPECIES_SORT: {


### PR DESCRIPTION
## Overview

I've done that on top of my previous PR that's why that branch is selected as the base one. We can change the base after merging the previous one.

When looking at a Look-Alike species detail page the user should be able to select on of the items on the table and see on the map the current population and the selected populations' boundaries.

**[Story link](https://www.pivotaltracker.com/story/show/153173338)**

### What could be improved

Refactor of selecting Look-Alike species to include that in router would be beneficial. I've experimented with that but it is too much work, that's why I came with a simpler solution.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] PR has a description that explains it
- [x] PR includes information for people to test it [e.g.: run `npm install`]
- [x] PR is not 2k commits long... please. :pray:

