### PR TITLE
Feature/French common name for species

### DIFF
--- a/api/controllers/countries.js
+++ b/api/controllers/countries.js
@@ -105,7 +105,7 @@ function getCountryCriticalSites(req, res) {
 }
 
 function getCountrySpecies(req, res) {
-  const query = `SELECT s.scientific_name, s.english_name, s.genus, s.family,
+  const query = `SELECT s.scientific_name, s.english_name, s.french_name, s.genus, s.family,
     s.species_id as id, string_agg(p.population_name, ', ') as populations, s.hyperlink,
     sc.country_status, s.iucn_category, sc.occurrence_status
     FROM species_main s
@@ -113,7 +113,7 @@ function getCountrySpecies(req, res) {
     INNER JOIN countries c on c.country_id = sc.country_id AND
       c.iso3 = '${req.params.iso}'
     INNER JOIN populations_iba p on p.species_main_id = s.species_id
-    GROUP BY s.scientific_name, s.english_name, s.genus, s.family, s.species_id, 1,
+    GROUP BY s.scientific_name, s.english_name, s.french_name, s.genus, s.family, s.species_id, 1,
     s.hyperlink, sc.country_status, s.iucn_category, s.taxonomic_sequence,
     sc.occurrence_status
     ORDER BY s.taxonomic_sequence`;
@@ -131,6 +131,7 @@ function getCountryPopulations(req, res) {
   const query = `SELECT
     s.scientific_name,
     s.english_name,
+    s.french_name,
     s.iucn_category,
     pi.wpepopid AS pop_id,
     s.species_id AS id,
@@ -164,6 +165,7 @@ function getCountryPopulations(req, res) {
 function getCountryPopsWithLookAlikeCounts(req, res) {
   const query = `SELECT sq.scientific_name AS original_species,
     sq.english_name,
+    sq.french_name,
     sq.population_name AS population, sq.a AS original_a,
     sq.b AS original_b, sq.c AS original_c, sq.wpepopid AS pop_id_origin,
     COUNT(*) AS confusion_species,
@@ -173,7 +175,7 @@ function getCountryPopsWithLookAlikeCounts(req, res) {
     (
       SELECT confusion_group,
       sm.species_id, sm.scientific_name,
-      sm.english_name, pi.the_geom, pi.population_name,
+      sm.english_name, sm.french_name, pi.the_geom, pi.population_name,
       pi.a, pi.b, pi.c, pi.wpepopid, sm.taxonomic_sequence
       FROM species_main AS sm
       INNER JOIN species_country AS sc
@@ -198,7 +200,7 @@ function getCountryPopsWithLookAlikeCounts(req, res) {
     AND ST_INTERSECTS(pi.the_geom, sq.the_geom)
     AND pi.species_main_id = sm.species_id
     GROUP BY sq.scientific_name,
-    sq.english_name, sq.population_name,
+    sq.english_name, sq.french_name, sq.population_name,
     sq.a, sq.b, sq.c, sq.wpepopid, sq.taxonomic_sequence
     ORDER BY sq.taxonomic_sequence ASC`;
 
@@ -218,6 +220,7 @@ function getCountryLookAlikeSpecies(req, res) {
     SELECT
       sm.scientific_name AS scientific_name,
       sm.english_name,
+      sm.french_name,
       sm.species_id AS id,
       pi.population_name AS population,
       pi.a,

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -321,6 +321,7 @@ async function getSpeciesResults(req, res) {
         sp.scientific_name,
         sp.genus,
         sp.english_name,
+        sp.french_name,
         sp.family,
         sp.species_id AS id,
         sp.iucn_category,
@@ -337,7 +338,7 @@ async function getSpeciesResults(req, res) {
       ${site_habitat ? 'INNER JOIN sites_habitats sh ON sh.site_id = ss.site_id' : ''}
       ${site_threat ? 'INNER JOIN sites_threats st ON st.site_id = ss.site_id' : ''}
       ${where.length > 0 && `WHERE ${where.join(' AND ')}` || ''}
-      GROUP BY sp.scientific_name, sp.family, sp.genus, sp.english_name, sp.species_id,
+      GROUP BY sp.scientific_name, sp.family, sp.genus, sp.english_name, sp.french_name, sp.species_id,
         sp.iucn_category, sp.hyperlink, sp.taxonomic_sequence
       ORDER by taxonomic_sequence ASC`;
     const data = await runQuery(query);
@@ -411,6 +412,7 @@ async function getPopulationsResults(req, res) {
     const query = `SELECT
       sp.scientific_name,
       sp.english_name,
+      sp.french_name,
       sp.iucn_category,
       pi.wpepopid AS pop_id,
       sp.species_id AS id,
@@ -440,7 +442,7 @@ async function getPopulationsResults(req, res) {
       ${site_habitat ? 'INNER JOIN sites_habitats sh ON sh.site_id = ss.site_id' : ''}
       ${site_threat ? 'INNER JOIN sites_threats st ON st.site_id = ss.site_id' : ''}
       ${where.length > 0 && `WHERE ${where.join(' AND ')}` || ''}
-      GROUP by sp.scientific_name, sp.english_name, sp.iucn_category, pi.wpepopid,
+      GROUP by sp.scientific_name, sp.english_name, sp.french_name, sp.iucn_category, pi.wpepopid,
       sp.species_id, pi.caf_action_plan, pi.eu_birds_directive, pi.a, pi.b, pi.c,
       pi.flyway_range, pi.year_start, pi.year_end, pi.size_min, pi.size_max,
       pi.population_name, pi.ramsar_criterion_6, sp.taxonomic_sequence

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -280,8 +280,8 @@ async function getSpeciesResults(req, res) {
     } = req.query;
 
     const joinCountries = !!(country || aewa_region || ramsar_region);
-    const joinSpeciesSites = !!(site || site_habitat || site_threat);
     const joinSites = !!(site || protection);
+    const joinSpeciesSites = !!(joinSites || site_habitat || site_threat);
     const joinPopulations = !!(aewa_table_1_status || cms_caf_action_plan || eu_birds_directive || multispecies_flyway || population_trend);
     const where = [];
     const addCondition = (column, param, collection = where) => { if (param) collection.push(condition(column, param)); };

--- a/api/controllers/sites.js
+++ b/api/controllers/sites.js
@@ -171,6 +171,7 @@ function getSitesSpecies(req, res) {
     query = `SELECT
       s.scientific_name,
       s.english_name,
+      s.french_name,
       s.species_id AS id,
       s.iucn_category,
       si.lat,
@@ -209,6 +210,7 @@ function getSitesSpecies(req, res) {
       p.population_name AS population,
       s.iucn_category,
       s.english_name,
+      s.french_name,
       s.scientific_name,
       si.site_name_clean AS site_name,
       s.hyperlink, ss.geometric_mean,

--- a/api/controllers/species.js
+++ b/api/controllers/species.js
@@ -224,6 +224,7 @@ function getPopulationsLookAlikeSpecies(req, res) {
   const query = `SELECT
     sm.scientific_name AS scientific_name,
     sm.english_name,
+    sm.french_name,
     pi.population_name AS population,
     pi.wpepopid,
     pi.a,

--- a/api/controllers/species.js
+++ b/api/controllers/species.js
@@ -3,7 +3,7 @@ const mergeNames = require('../helpers/index').mergeNames;
 const { runQuery } = require('../helpers');
 
 function getSpeciesList(req, res) {
-  const query = `SELECT s.scientific_name, s.english_name, s.genus, s.family,
+  const query = `SELECT s.scientific_name, s.english_name, s.french_name, s.genus, s.family,
     s.species_id as id, s.hyperlink, s.iucn_category, aewa_annex_2
     FROM species_main s
     ORDER BY s.taxonomic_sequence`;
@@ -24,7 +24,7 @@ function getSpeciesList(req, res) {
 }
 
 function getSpeciesDetails(req, res) {
-  const query = `SELECT s.scientific_name, s.english_name, s.family,
+  const query = `SELECT s.scientific_name, s.english_name, s.french_name, s.family,
     s.species_id as id, s.iucn_category, s.hyperlink
     FROM species_main s
     WHERE s.species_id = ${req.params.id}
@@ -38,6 +38,7 @@ function getSpeciesDetails(req, res) {
           species: [{
             scientific_name: row.scientific_name,
             english_name: row.english_name,
+            french_name: row.french_name,
             family: row.family,
             id: row.id,
             iucn_category: row.iucn_category,
@@ -170,7 +171,7 @@ function getSpeciesPopulation(req, res) {
 
 function getSpeciesLookAlikeSpecies(req, res) {
   const query = `SELECT sq.scientific_name AS original_species,
-    sq.species_id, sq.english_name,
+    sq.species_id, sq.english_name, sq.french_name,
     sq.population_name AS population, sq.a AS original_a,
     sq.b AS original_b, sq.c AS original_c, sq.wpepopid AS pop_id_origin,
     COUNT(*) AS confusion_species,
@@ -180,7 +181,7 @@ function getSpeciesLookAlikeSpecies(req, res) {
     (
       SELECT confusion_group,
       sm.species_id, sm.scientific_name,
-      sm.english_name, pi.the_geom,
+      sm.english_name, sm.french_name, pi.the_geom,
       pi.population_name, pi.a, pi.b, pi.c, pi.wpepopid
       FROM species_main AS sm
       INNER JOIN populations_iba AS pi
@@ -196,7 +197,7 @@ function getSpeciesLookAlikeSpecies(req, res) {
     ON pi.species_main_id = sm.species_id
     AND ST_INTERSECTS(sq.the_geom, pi.the_geom)
     GROUP BY sq.scientific_name,
-    sq.english_name, sq.population_name,
+    sq.english_name, sq.french_name, sq.population_name,
     sq.a, sq.b, sq.c, sq.wpepopid, sq.species_id
     ORDER BY sq.population_name ASC`;
 

--- a/api/controllers/threshold.js
+++ b/api/controllers/threshold.js
@@ -7,6 +7,7 @@ function getSpeciesByPosition(req, res) {
     p.species_main_id AS id,
     p.scientificname AS scientific_name,
     p.commonname AS english_name,
+    sm.french_name,
     p.population_name AS population, p.a, p.b, p.c, p.table_1_status,
     sm.iucn_category, p.caf_action_plan, p.eu_birds_directive,
     p.species, p.wpepopid, p.flyway_range, p.year_start,

--- a/app/components/pages/SpeciesDetailPage.js
+++ b/app/components/pages/SpeciesDetailPage.js
@@ -35,6 +35,8 @@ class SpeciesDetailPage extends React.Component {
   }
 
   render() {
+    const nameColumn = this.props.lang === 'fr' ? 'french_name' : 'english_name';
+
     return (
       <div className="l-page">
         <div className="l-navigation">
@@ -55,10 +57,10 @@ class SpeciesDetailPage extends React.Component {
                     <div className="list">
                       <div className="item">
                         <div className="label">
-                          {this.context.t('english_name')}
+                            {this.context.t(nameColumn)}
                         </div>
                         <div className="value">
-                          {this.props.stats.species[0].english_name}
+                          {this.props.stats.species[0][nameColumn]}
                         </div>
                       </div>
                       <div className="item">

--- a/app/constants/tables.js
+++ b/app/constants/tables.js
@@ -7,14 +7,14 @@ export const TABLES = {
 };
 
 export const ALL_COUNTRY_COLUMNS = {
-  species: ['scientific_name', 'english_name', 'iucn_category', 'country_status', 'occurrence_status'],
-  populations: ['scientific_name', 'english_name', 'iucn_category', 'population',
+  species: ['scientific_name', 'english_name', 'french_name', 'iucn_category', 'country_status', 'occurrence_status'],
+  populations: ['scientific_name', 'english_name', 'french_name', 'iucn_category', 'population',
                 'a', 'b', 'c', 'caf_action_plan', 'eu_birds_directive', 'flyway_range',
                 'year_start', 'year_end', 'size_min', 'size_max', 'ramsar_criterion'],
   criticalSites: ['csn_name', 'protected', 'csn_species', 'total_percentage'],
-  lookAlikeSpecies: ['original_species', 'english_name', 'population', 'original_a', 'original_b',
+  lookAlikeSpecies: ['original_species', 'english_name', 'french_name', 'population', 'original_a', 'original_b',
                      'original_c', 'confusion_species', 'confusion_species_as'],
-  lookAlikeSpeciesPopulation: ['scientific_name', 'english_name', 'population', 'a', 'b', 'c'],
+  lookAlikeSpeciesPopulation: ['scientific_name', 'english_name', 'french_name', 'population', 'a', 'b', 'c'],
   sites: ['site_name', 'protected', 'iba_species', 'iba_in_danger']
 };
 
@@ -31,9 +31,9 @@ export const DEFAULT_COUNTRY_COLUMNS = {
 export const ALL_SITES_COLUMNS = {
   csn: ['country', 'csn_name', 'protected', 'csn', 'total_percentage'],
   iba: ['country', 'site_name', 'protected', 'iba_species', 'iba_in_danger'],
-  ibaSpecies: ['scientific_name', 'english_name', 'iucn_category', 'season', 'start',
+  ibaSpecies: ['scientific_name', 'english_name', 'french_name', 'iucn_category', 'season', 'start',
                'end', 'minimum', 'maximum', 'geometric_mean', 'units', 'iba_criteria'],
-  csnSpecies: ['scientific_name', 'english_name', 'iucn_category', 'population',
+  csnSpecies: ['scientific_name', 'english_name', 'french_name', 'iucn_category', 'population',
                'season', 'start', 'end', 'minimum', 'maximum', 'geometric_mean', 'units',
                'percentfly', 'csn1', 'csn2']
 };
@@ -47,13 +47,13 @@ export const DEFAULT_SITES_COLUMNS = {
 };
 
 export const ALL_SPECIES_COLUMNS = {
-  over: ['scientific_name', 'english_name', 'genus', 'family', 'iucn_category',
+  over: ['scientific_name', 'english_name', 'french_name', 'genus', 'family', 'iucn_category',
     'aewa_annex_2'],
   population: ['population', 'iucn_category', 'a', 'b', 'c',
     'caf_action_plan', 'eu_birds_directive', 'flyway_range', 'year_start',
     'year_end', 'size_min', 'size_max', 'ramsar_criterion'],
   lookAlikeSpecies: ['population', 'original_a', 'original_b', 'original_c', 'confusion_species', 'confusion_species_as'],
-  lookAlikeSpeciesPopulation: ['scientific_name', 'english_name', 'population', 'a', 'b', 'c'],
+  lookAlikeSpeciesPopulation: ['scientific_name', 'english_name', 'french_name', 'population', 'a', 'b', 'c'],
   criticalSites: ['country', 'csn_site_name', 'protected', 'population',
     'season', 'start', 'end', 'minimum', 'maximum', 'geometric_mean',
     'units', 'percentfly', 'csn1', 'csn2'],
@@ -72,7 +72,7 @@ export const DEFAULT_SPECIES_COLUMNS = {
 };
 
 export const ALL_THRESHOLD_COLUMNS = [
-  'scientific_name', 'english_name', 'iucn_category',
+  'scientific_name', 'english_name', 'french_name', 'iucn_category',
   'population', 'a', 'b', 'c', 'caf_action_plan', 'eu_birds_directive',
   'flyway_range', 'year_start', 'year_end', 'size_min', 'size_max',
   'ramsar_criterion'

--- a/app/containers/advanced-search/SearchTable.js
+++ b/app/containers/advanced-search/SearchTable.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import SearchTable from 'components/advanced-search/SearchTable';
+import { filterColumnsBasedOnLanguage } from 'helpers/language';
 import { filterData } from 'helpers/filters';
 
 const mapStateToProps = (state) => {
@@ -12,7 +13,7 @@ const mapStateToProps = (state) => {
     data: filterData({ data, columns, filter, columnFilter }),
     category: state.search.selectedCategory,
     columns,
-    allColumns: state.search.allColumns
+    allColumns: filterColumnsBasedOnLanguage(state.search.allColumns, state.i18nState.lang)
   };
 };
 

--- a/app/containers/countries/CountriesTable.js
+++ b/app/containers/countries/CountriesTable.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import CountriesTable from 'components/countries/CountriesTable';
+import { filterColumnsBasedOnLanguage } from 'helpers/language';
 import { filterData } from 'helpers/filters';
 import {
   selectCountriesTableItem,
@@ -27,7 +28,7 @@ const mapStateToProps = (state) => {
     category: countries.selectedCategory,
     data: filterData({ data, columns, filter: countries.searchFilter, columnFilter: countries.columnFilter }),
     columns,
-    allColumns: countries.allColumns,
+    allColumns: filterColumnsBasedOnLanguage(countries.allColumns, state.i18nState.lang),
     selectedTableItem: countries.selectedTableItem,
     selectedLASpeciesPopulation: getSelectedSpeciesPopulation(countries)
   };

--- a/app/containers/pages/SpeciesDetailPage.js
+++ b/app/containers/pages/SpeciesDetailPage.js
@@ -22,7 +22,8 @@ const mapStateToProps = (state) => ({
   selectedPopulationId: state.species.selectedLASpeciesPopulation,
   category: state.species.selectedCategory,
   stats: state.species.stats || false,
-  data: getSpeciesData(state.species)
+  data: getSpeciesData(state.species),
+  lang: state.i18nState.lang
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/containers/sites/SitesDetailTable.js
+++ b/app/containers/sites/SitesDetailTable.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import SitesDetailTable from 'components/sites/SitesDetailTable';
+import { filterColumnsBasedOnLanguage } from 'helpers/language';
 import { filterData } from 'helpers/filters';
 
 const mapStateToProps = (state) => {
@@ -15,7 +16,7 @@ const mapStateToProps = (state) => {
     data: filterData({ data, columns, filter: sites.searchFilter, columnFilter: sites.columnFilter }),
     type: sites.type,
     columns,
-    allColumns: sites.allColumns
+    allColumns: filterColumnsBasedOnLanguage(sites.allColumns, state.i18nState.lang)
   };
 };
 

--- a/app/containers/species/SpeciesDetailTable.js
+++ b/app/containers/species/SpeciesDetailTable.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import SpeciesDetailTable from 'components/species/SpeciesDetailTable';
+import { filterColumnsBasedOnLanguage } from 'helpers/language';
 import { filterData } from 'helpers/filters';
 import { selectSpeciesTableItem } from 'actions/species';
 
@@ -29,7 +30,7 @@ const mapStateToProps = (state) => {
   return {
     category: state.species.selectedCategory,
     data: filterData({ data, columns, filter, columnFilter }),
-    allColumns: state.species.allColumns,
+    allColumns: filterColumnsBasedOnLanguage(state.species.allColumns, state.i18nState.lang),
     columns,
     selectedLASpeciesPopulation: getSelectedSpeciesPopulation(state.species),
     selectedTableItem: species.selectedTableItem

--- a/app/containers/species/SpeciesTable.js
+++ b/app/containers/species/SpeciesTable.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import SpeciesTable from 'components/species/SpeciesTable';
 import { filterData } from 'helpers/filters';
+import { filterColumnsBasedOnLanguage } from 'helpers/language';
 
 const mapStateToProps = (state) => {
   const columns = state.species.columns;
@@ -10,7 +11,7 @@ const mapStateToProps = (state) => {
   return {
     data: filterData({ data, columns, filter }),
     columns,
-    allColumns: state.species.allColumns
+    allColumns: filterColumnsBasedOnLanguage(state.species.allColumns, state.i18nState.lang)
   };
 };
 

--- a/app/containers/threshold/ThresholdTable.js
+++ b/app/containers/threshold/ThresholdTable.js
@@ -1,13 +1,18 @@
 import { connect } from 'react-redux';
 import ThresholdTable from 'components/threshold/ThresholdTable';
 import { getSitesList } from 'actions/sites';
+import { filterColumnsBasedOnLanguage } from 'helpers/language';
 import { filterData } from 'helpers/filters';
 
-const mapStateToProps = ({ threshold: { list, allColumns, columns, searchFilter, columnFilter } }) => ({
-  data: filterData({ data: list, columns, filter: searchFilter, columnFilter }),
-  allColumns,
-  columns
-});
+const mapStateToProps = (state) => {
+  const { list, allColumns, columns, searchFilter, columnFilter } = state.threshold;
+
+  return {
+    data: filterData({ data: list, columns, filter: searchFilter, columnFilter }),
+    allColumns: filterColumnsBasedOnLanguage(allColumns, state.i18nState.lang),
+    columns
+  };
+};
 
 const mapDispatchToProps = (dispatch) => ({
   getSitesList: (page, search) => dispatch(getSitesList(page, search))

--- a/app/helpers/language.js
+++ b/app/helpers/language.js
@@ -1,0 +1,6 @@
+export function filterColumnsBasedOnLanguage(columns, lang) {
+  return columns.filter((column) => (
+    !(column === 'english_name' && lang === 'fr') &&
+    !(column === 'french_name' && lang !== 'fr')
+  ));
+}

--- a/app/reducers/withTable.js
+++ b/app/reducers/withTable.js
@@ -56,6 +56,19 @@ export default function (tableName, reducer) {
           selectedTableItem: action.payload
         };
       }
+      case 'REDUX_I18N_SET_LANGUAGE': {
+        const lang = action.lang;
+        const mapNameColumn = (column) => {
+          if (column === 'english_name' && lang === 'fr') return 'french_name';
+          if (column === 'french_name' && lang !== 'fr') return 'english_name';
+          return column;
+        };
+
+        return {
+          ...state,
+          columns: state.columns.map(mapNameColumn)
+        };
+      }
       default:
         return state;
     }


### PR DESCRIPTION
## Overview

When user selected French as their language the system should fetch the French common name instead of the english Common name.

Changing English common name to French common name when French is selected in places like:
- Countries/Species
- Countries/Look-alike Species
- Countries/Look-alike Species - selected population table
- Site Details Table
- Species
- Species Details/Header
- Species Details/Look-alike Species - selected population table
- Ramsar Threshold
- Advanced Search Species

**[Story link](https://www.pivotaltracker.com/story/show/153452252)**

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] PR has a description that explains it
- [x] PR includes information for people to test it [e.g.: run `npm install`]
- [x] PR is not 2k commits long... please. :pray:

