### PR TITLE
Fix/advanced search after feedback

### DIFF
--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -110,12 +110,13 @@ async function getIBAsResults(req, res) {
     addCondition('sh.habitat_id', site_habitat);
     addCondition('st.threat_id', site_threat);
     // species filters
+    // TODO: ask how exactly this filter should work, maybe AND
     if (species || genus || family) {
       const speciesConditions = [];
       addCondition('sp.species_id', species, speciesConditions);
       addCondition('sp.genus', genus, speciesConditions);
       addCondition('sp.family', family, speciesConditions);
-      where.push(speciesConditions.join(' OR '));
+      where.push(`(${speciesConditions.join(' OR ')})`);
     }
     addCondition('sp.iucn_category', red_list_status);
     addCondition('sp.aewa_annex_2', aewa_annex_2);
@@ -202,7 +203,7 @@ async function getCriticalSitesResults(req, res) {
       addCondition('sp.species_id', species, speciesConditions);
       addCondition('sp.genus', genus, speciesConditions);
       addCondition('sp.family', family, speciesConditions);
-      where.push(speciesConditions.join(' OR '));
+      where.push(`(${speciesConditions.join(' OR ')})`);
     }
     addCondition('sp.iucn_category', red_list_status);
     addCondition('sp.aewa_annex_2', aewa_annex_2);
@@ -292,7 +293,7 @@ async function getSpeciesResults(req, res) {
       addCondition('sp.species_id', species, speciesConditions);
       addCondition('sp.genus', genus, speciesConditions);
       addCondition('sp.family', family, speciesConditions);
-      where.push(speciesConditions.join(' OR '));
+      where.push(`(${speciesConditions.join(' OR ')})`);
     }
     addCondition('sp.aewa_annex_2', aewa_annex_2);
     addCondition('sp.iucn_category', red_list_status);
@@ -385,7 +386,7 @@ async function getPopulationsResults(req, res) {
       addCondition('sp.species_id', species, speciesConditions);
       addCondition('sp.genus', genus, speciesConditions);
       addCondition('sp.family', family, speciesConditions);
-      where.push(speciesConditions.join(' OR '));
+      where.push(`(${speciesConditions.join(' OR ')})`);
     }
     addCondition('sp.aewa_annex_2', aewa_annex_2);
     addCondition('sp.iucn_category', red_list_status);

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -107,15 +107,9 @@ async function getIBAsResults(req, res) {
     addCondition('protection_status', protection);
     addCondition('sh.habitat_id', site_habitat);
     addCondition('st.threat_id', site_threat);
-    // species filters
-    // TODO: ask how exactly this filter should work, maybe AND
-    if (species || genus || family) {
-      const speciesConditions = [];
-      addCondition('sp.species_id', species, speciesConditions);
-      addCondition('sp.genus', genus, speciesConditions);
-      addCondition('sp.family', family, speciesConditions);
-      where.push(`(${speciesConditions.join(' OR ')})`);
-    }
+    addCondition('sp.species_id', species);
+    addCondition('sp.genus', genus);
+    addCondition('sp.family', family);
     addCondition('sp.iucn_category', red_list_status);
     addCondition('sp.aewa_annex_2', aewa_annex_2);
     addCondition('spt.threat_level_1', species_threat);
@@ -195,14 +189,9 @@ async function getCriticalSitesResults(req, res) {
     addCondition('protection_status', protection);
     addCondition('sh.habitat_id', site_habitat);
     addCondition('st.threat_id', site_threat);
-    // species filters
-    if (species || genus || family) {
-      const speciesConditions = [];
-      addCondition('sp.species_id', species, speciesConditions);
-      addCondition('sp.genus', genus, speciesConditions);
-      addCondition('sp.family', family, speciesConditions);
-      where.push(`(${speciesConditions.join(' OR ')})`);
-    }
+    addCondition('sp.species_id', species);
+    addCondition('sp.genus', genus);
+    addCondition('sp.family', family);
     addCondition('sp.iucn_category', red_list_status);
     addCondition('sp.aewa_annex_2', aewa_annex_2);
     addCondition('spt.threat_level_1', species_threat);
@@ -285,14 +274,9 @@ async function getSpeciesResults(req, res) {
     const where = [];
     const addCondition = (column, param, collection = where) => { if (param) collection.push(condition(column, param)); };
 
-    // species filters
-    if (species || genus || family) {
-      const speciesConditions = [];
-      addCondition('sp.species_id', species, speciesConditions);
-      addCondition('sp.genus', genus, speciesConditions);
-      addCondition('sp.family', family, speciesConditions);
-      where.push(`(${speciesConditions.join(' OR ')})`);
-    }
+    addCondition('sp.species_id', species);
+    addCondition('sp.genus', genus);
+    addCondition('sp.family', family);
     addCondition('sp.aewa_annex_2', aewa_annex_2);
     addCondition('sp.iucn_category', red_list_status);
     addCondition('spt.threat_level_1', species_threat);
@@ -378,14 +362,9 @@ async function getPopulationsResults(req, res) {
     const where = [];
     const addCondition = (column, param, collection = where) => { if (param) collection.push(condition(column, param)); };
 
-    // species filters
-    if (species || genus || family) {
-      const speciesConditions = [];
-      addCondition('sp.species_id', species, speciesConditions);
-      addCondition('sp.genus', genus, speciesConditions);
-      addCondition('sp.family', family, speciesConditions);
-      where.push(`(${speciesConditions.join(' OR ')})`);
-    }
+    addCondition('sp.species_id', species);
+    addCondition('sp.genus', genus);
+    addCondition('sp.family', family);
     addCondition('sp.aewa_annex_2', aewa_annex_2);
     addCondition('sp.iucn_category', red_list_status);
     addCondition('spt.threat_level_1', species_threat);

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -104,7 +104,7 @@ async function getIBAsResults(req, res) {
     addCondition('c.country_id', country);
     addCondition('c.aewa_region', aewa_region);
     addCondition('c.ramsar_region', ramsar_region);
-    addCondition('protection_status', protection);
+    addCondition('s.protection_status', protection);
     addCondition('sh.habitat_id', site_habitat);
     addCondition('st.threat_id', site_threat);
     addCondition('sp.species_id', species);
@@ -186,7 +186,7 @@ async function getCriticalSitesResults(req, res) {
     addCondition('c.country_id', country);
     addCondition('c.aewa_region', aewa_region);
     addCondition('c.ramsar_region', ramsar_region);
-    addCondition('protection_status', protection);
+    addCondition('s.protection_status', protection);
     addCondition('sh.habitat_id', site_habitat);
     addCondition('st.threat_id', site_threat);
     addCondition('sp.species_id', species);
@@ -282,16 +282,16 @@ async function getSpeciesResults(req, res) {
     addCondition('spt.threat_level_1', species_threat);
     addCondition('sph.habitat_level_1', species_habitat_association);
     // sites filters
+    addCondition('s.site_id', site);
     addCondition('s.protection_status', protection);
+    addCondition('sh.habitat_id', site_habitat);
+    addCondition('st.threat_id', site_threat);
     addCondition('c.aewa_region', aewa_region);
     addCondition('c.ramsar_region', ramsar_region);
     if (country && !site) {
       addCondition('sc.country_id', country);
       where.push("sc.country_status != 'Vagrant'");
     }
-    addCondition('s.site_id', site);
-    addCondition('sh.habitat_id', site_habitat);
-    addCondition('st.threat_id', site_threat);
     // population filters
     addCondition('trim(pi.table_1_status)', aewa_table_1_status);
     addCondition('pi.caf_action_plan', cms_caf_action_plan);
@@ -370,16 +370,16 @@ async function getPopulationsResults(req, res) {
     addCondition('spt.threat_level_1', species_threat);
     addCondition('sph.habitat_level_1', species_habitat_association);
     // sites filters
+    addCondition('s.site_id', site);
     addCondition('s.protection_status', protection);
+    addCondition('sh.habitat_id', site_habitat);
+    addCondition('st.threat_id', site_threat);
     addCondition('c.aewa_region', aewa_region);
     addCondition('c.ramsar_region', ramsar_region);
     if (country && !site) {
       addCondition('sc.country_id', country);
       where.push("sc.country_status != 'Vagrant'");
     }
-    addCondition('s.site_id', site);
-    addCondition('sh.habitat_id', site_habitat);
-    addCondition('st.threat_id', site_threat);
     // population filters
     addCondition('trim(pi.table_1_status)', aewa_table_1_status);
     addCondition('pi.caf_action_plan', cms_caf_action_plan);

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -330,7 +330,7 @@ async function getSpeciesResults(req, res) {
       FROM species_main sp
       ${joinPopulations ? 'INNER JOIN populations_iba pi ON pi.species_main_id = sp.species_id' : ''}
       ${joinCountries &&
-        `INNER JOIN species_country sc ON sc.species_id = sc.species_id
+        `INNER JOIN species_country sc ON sc.species_id = sp.species_id
          INNER JOIN countries c ON c.country_id = sc.country_id` || ''}
       ${joinSpeciesSites ? 'INNER JOIN species_sites ss ON ss.species_id = sp.species_id' : ''}
       ${joinSites ? 'INNER JOIN sites s ON ss.site_id = s.site_id' : ''}
@@ -433,7 +433,7 @@ async function getPopulationsResults(req, res) {
       FROM populations_iba AS pi
       INNER JOIN species_main sp ON pi.species_main_id = sp.species_id
       ${joinCountries &&
-        `INNER JOIN species_country sc ON sc.species_id = sc.species_id
+        `INNER JOIN species_country sc ON sc.species_id = sp.species_id
          INNER JOIN countries c ON c.country_id = sc.country_id
          INNER JOIN world_borders AS wb ON wb.iso3 = sc.iso AND ST_INTERSECTS(pi.the_geom, wb.the_geom)` || ''}
       ${joinSpeciesSites ? 'INNER JOIN species_sites ss ON ss.species_id = sp.species_id' : ''}

--- a/app/components/pages/AdvancedSearchPage.js
+++ b/app/components/pages/AdvancedSearchPage.js
@@ -227,8 +227,6 @@ AdvancedSearchPage.contextTypes = {
 AdvancedSearchPage.propTypes = {
   data: PropTypes.any,
   isFetching: PropTypes.bool.isRequired,
-  columns: PropTypes.any,
-  allColumns: PropTypes.any,
   options: PropTypes.object,
   getOptions: PropTypes.func.isRequired,
   onSearch: PropTypes.func.isRequired

--- a/app/components/pages/AdvancedSearchPage.js
+++ b/app/components/pages/AdvancedSearchPage.js
@@ -14,24 +14,29 @@ const SEARCH_GROUPS = {
 };
 const SINGLE_SELECTS = ['aewa_annex_2', 'eu_birds_directive', 'cms_caf_action_plan'];
 
-function filterSitesByCountry(countries, sites) {
+function filterSitesByCountry(sites, countries) {
   if (!countries) return sites;
   const countryIds = countries.map((country) => country.value);
-  return sites.filter((site) => countryIds.indexOf(site.country_id) > -1);
+  return sites.filter((site) => countryIds.includes(site.country_id));
 }
-function filterSpeciesByGenusAndFamily(genus, families, species) {
+function filterSpeciesByGenusAndFamily(species, genus, families) {
   if (!genus && !families) return species;
   if (!genus) {
     const familyValues = families.map((item) => item.value);
-    return species.filter((site) => familyValues.indexOf(site.family) > -1);
+    return species.filter((site) => familyValues.includes(site.family));
   }
   if (!families) {
     const genusValues = genus.map((item) => item.value);
-    return species.filter((site) => genusValues.indexOf(site.genus) > -1);
+    return species.filter((site) => genusValues.includes(site.genus));
   }
   const genusValues = genus.map((item) => item.value);
   const familyValues = families.map((item) => item.value);
-  return species.filter((site) => genusValues.indexOf(site.genus) > -1 || familyValues.indexOf(site.family) > -1);
+  return species.filter((site) => genusValues.includes(site.genus) || familyValues.includes(site.family));
+}
+function filterGenusByFamily(genus, families) {
+  if (!families) return genus;
+  const familyValues = families.map((f) => f.value);
+  return genus.filter((g) => familyValues.includes(g.family));
 }
 
 class AdvancedSearchPage extends React.Component {
@@ -88,11 +93,15 @@ class AdvancedSearchPage extends React.Component {
     switch (section) {
       case 'site':
         return filters.country
-          ? filterSitesByCountry(filters.country, options) : options;
+             ? filterSitesByCountry(options, filters.country) : options;
+      case 'genus':
+        return filters.family
+             ? filterGenusByFamily(options, filters.family)
+             : options;
       case 'species':
         return filters.genus && filters.family
-          ? filterSpeciesByGenusAndFamily(filters.genus, filters.family, options)
-          : options;
+             ? filterSpeciesByGenusAndFamily(options, filters.genus, filters.family)
+             : options;
       default:
         return options;
     }

--- a/app/constants/tables.js
+++ b/app/constants/tables.js
@@ -79,3 +79,22 @@ export const ALL_THRESHOLD_COLUMNS = [
 ];
 
 export const DEFAULT_THRESHOLD_COLUMNS = ['scientific_name', 'iucn_category', 'population', 'a', 'b', 'c', 'ramsar_criterion'];
+
+export const SEARCH_COLUMNS = {
+  species: {
+    columns: DEFAULT_SPECIES_COLUMNS.over,
+    allColumns: ALL_SPECIES_COLUMNS.over
+  },
+  ibas: {
+    columns: DEFAULT_SITES_COLUMNS.iba,
+    allColumns: ALL_SITES_COLUMNS.iba
+  },
+  criticalSites: {
+    columns: DEFAULT_SITES_COLUMNS.csn,
+    allColumns: ALL_SITES_COLUMNS.csn
+  },
+  populations: {
+    columns: ['scientific_name', ...DEFAULT_SPECIES_COLUMNS.population],
+    allColumns: ['scientific_name', ...ALL_SPECIES_COLUMNS.population]
+  }
+};

--- a/app/constants/tables.js
+++ b/app/constants/tables.js
@@ -95,6 +95,6 @@ export const SEARCH_COLUMNS = {
   },
   populations: {
     columns: ['scientific_name', ...DEFAULT_SPECIES_COLUMNS.population],
-    allColumns: ['scientific_name', ...ALL_SPECIES_COLUMNS.population]
+    allColumns: ['scientific_name', 'english_name', 'french_name', ...ALL_SPECIES_COLUMNS.population]
   }
 };

--- a/app/containers/pages/AdvancedSearch.js
+++ b/app/containers/pages/AdvancedSearch.js
@@ -1,17 +1,11 @@
 import { connect } from 'react-redux';
 import AdvancedSearch from 'components/pages/AdvancedSearchPage';
 import { getSearchOptions, getSearchResults } from 'actions/search';
-import {
-  ALL_SPECIES_COLUMNS,
-  DEFAULT_SPECIES_COLUMNS
-} from 'constants/tables';
 
 const mapStateToProps = (state) => ({
   options: state.search.options,
   data: state.search.list,
-  isFetching: state.search.isFetching,
-  columns: DEFAULT_SPECIES_COLUMNS.over,
-  allColumns: ALL_SPECIES_COLUMNS.over
+  isFetching: state.search.isFetching
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/reducers/search.js
+++ b/app/reducers/search.js
@@ -4,10 +4,7 @@ import {
   BEFORE_GET_SEARCH_RESULTS
 } from 'constants/action-types';
 import {
-  ALL_SITES_COLUMNS,
-  ALL_SPECIES_COLUMNS,
-  DEFAULT_SITES_COLUMNS,
-  DEFAULT_SPECIES_COLUMNS,
+  SEARCH_COLUMNS,
   TABLES
 } from 'constants/tables';
 
@@ -26,27 +23,8 @@ const initialState = {
   }
 };
 
-const COLUMNS = {
-  species: {
-    columns: DEFAULT_SPECIES_COLUMNS.over,
-    allColumns: ALL_SPECIES_COLUMNS.over
-  },
-  ibas: {
-    columns: DEFAULT_SITES_COLUMNS.iba,
-    allColumns: ALL_SITES_COLUMNS.iba
-  },
-  criticalSites: {
-    columns: DEFAULT_SITES_COLUMNS.csn,
-    allColumns: ALL_SITES_COLUMNS.csn
-  },
-  populations: {
-    columns: DEFAULT_SPECIES_COLUMNS.population,
-    allColumns: ALL_SPECIES_COLUMNS.population
-  }
-};
-
 function getColumns(selectedCategory) {
-  return COLUMNS[selectedCategory] || {
+  return SEARCH_COLUMNS[selectedCategory] || {
     columns: [],
     allColumns: []
   };


### PR DESCRIPTION
## Overview

A few fixes after getting the feedback from the client about advanced search.

1. Changing the way species filters work. (AND instead of OR).
2. Fixing species_country INNER JOIN.
3. AEWA Table 1 status filter is now using table_1_status column.
4. Adding species name to population results table. (scientific and English/French)

### Checklist

- [ ] PR has a name that won't get you publicly shamed for vagueness
- [ ] PR has a description that explains it
- [ ] PR includes information for people to test it [e.g.: run `npm install`]
- [ ] PR is not 2k commits long... please. :pray:

