### PR TITLE
Added additional check when filter parse countries

### DIFF
--- a/app/components/countries/CountriesMap.js
+++ b/app/components/countries/CountriesMap.js
@@ -140,9 +140,8 @@ class CountriesMap extends PopulationMap {
 
     // Filter in play
     if (searchFilter && searchFilter.length > 0) {
-      const { country } = countries.find((c) => c.iso3 === iso) || {};
-
-      return country.toLowerCase().includes(searchFilter.toLowerCase()) ? SHOW_STYLE : HIDE_STYLE;
+      const { country } = countries.find(c => c.iso3 === iso) || {};
+      return country && country.toLowerCase().includes(searchFilter.toLowerCase()) ? SHOW_STYLE : HIDE_STYLE;
     }
 
     return SHOW_STYLE; // Unfiltered, tastes great.


### PR DESCRIPTION
## Overview
This PR adds additional control to display countries when filter is active.
It resolves problem when some countries show all the time when filter is active.
Andorra and Kosovo are not in countries list localhost:3000/api/countries ... To fix this problem, we need to add them to the database too.
## [Issue](https://github.com/Vizzuality/csn-tool/issues/142)
### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] PR has a description that explains it
- [ ] PR includes information for people to test it [e.g.: run `npm install`]
- [ ] PR is not 2k commits long... please. :pray:

