### PR TITLE
Added culumns site_id, population_id, lon, lat to species triggerCriticalSuitability table

### DIFF
--- a/api/controllers/species.js
+++ b/api/controllers/species.js
@@ -336,8 +336,14 @@ function getPopulationVulnerability(req, res) {
 }
 
 function getTriggerCriticalSitesSuitability(req, res) {
-  const query = `SELECT sites.country, sites.site_name_clean AS csn_site_name,
+  const query = `SELECT 
+    sites.country, 
+    sites.site_name_clean AS csn_site_name,
+    sites.site_id,
+    sites.lon,
+    sites.lat,
     t2a.populationname AS population_name,
+    t2a.wpepopid AS pop_id,
     t2a.season, t2a.percentfly, t2a.current_suitability,
     t2a.future_suitability, ROUND(CAST(change AS numeric), 2) AS change_suitability,
     threshold,

--- a/app/constants/tables.js
+++ b/app/constants/tables.js
@@ -67,7 +67,7 @@ export const ALL_SPECIES_COLUMNS = {
   populationVulnerability: ['population_name', 'season', 'change_in_suitability_of_all_sites',
     'change_in_number_of_suitable_sites', 'change_in_suitability_of_critical_sites',
     'change_in_proportion_supported', 'range_change', 'range_overlap'],
-  triggerCriticalSuitability: ['country', 'csn_site_name', 'population_name',
+  triggerCriticalSuitability: ['country', 'site_id', 'lat', 'lon', 'csn_site_name', 'pop_id', 'population_name',
     'season', 'percentfly', 'current_suitability', 'future_suitability',
     'change_suitability', 'threshold', 'season_ev']
 };


### PR DESCRIPTION
## Overview
This PR adds site_id, population_id, lon, lat columns to species-detail page (triggerCriticalSuitability  table).
Changes make on FE(added columns) and API (changed SQL requests).

## Testing instructions
1. Run the project
2. Go to /en/species/22679763/triggerCriticalSuitability?zoom=4&lat=-1.1468281041475625&lng=15.816666665047187&view=map
3. Add new culumns to table

### [Issue](https://github.com/Vizzuality/csn-tool/issues/146)


### Checklist

- [ ] PR has a name that won't get you publicly shamed for vagueness
- [ ] PR has a description that explains it
- [ ] PR includes information for people to test it [e.g.: run `npm install`]
- [ ] PR is not 2k commits long... please. :pray:

